### PR TITLE
Not fetching last four digits of a card if there's no default card

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -538,7 +538,7 @@ class StripeGateway {
 	 */
 	protected function getLastFourCardDigits($customer)
 	{
-		return $customer->cards->retrieve($customer->default_card)->last4;
+		return is_null($customer->default_card) ? null : $customer->cards->retrieve($customer->default_card)->last4;
 	}
 
 	/**


### PR DESCRIPTION
Stripe allows us to create a customer without any card.
In that case trying to fetch last four digits of the default card after user is subscribed to a plan throws error.
This is possible when user is trying to subscribe to a free plan and app doesn't require them to enter their credit card info.