### PR TITLE
Added billingCycleAnchor option for subsciption create/update.

### DIFF
--- a/src/Laravel/Cashier/Invoice.php
+++ b/src/Laravel/Cashier/Invoice.php
@@ -174,7 +174,7 @@ class Invoice {
 	{
 		setlocale(LC_MONETARY, $this->billable->getCurrencyLocale());
 
-		return round(money_format('%i', ($this->subtotal / 100) - ($this->total / 100)), 2);
+		return round((($this->subtotal - $this->total) / 100), 2);
 	}
 
 	/**

--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -55,6 +55,13 @@ class StripeGateway {
 	protected $skipTrial = false;
 
 	/**
+	 * Indicates what the billing cycle period end should be.
+	 *
+	 * @var bool
+	 */
+	protected $billingCycleAnchor;
+
+	/**
 	 * Create a new Stripe gateway instance.
 	 *
 	 * @param  \Laravel\Cashier\BillableInterface   $billable
@@ -116,6 +123,7 @@ class StripeGateway {
 		$payload = [
 			'plan' => $this->plan, 'prorate' => $this->prorate,
 			'quantity' => $this->quantity, 'trial_end' => $this->getTrialEndForUpdate(),
+			'billing_cycle_anchor' => $this->billingCycleAnchor
 		];
 
 		if ($this->coupon) $payload['coupon'] = $this->coupon;
@@ -672,6 +680,18 @@ class StripeGateway {
 		{
 			return Carbon::createFromTimestamp($customer->subscription->trial_end);
 		}
+	}
+
+	/**
+	 * Set the billing cycle anchor value.
+	 *
+	 * @var string|null
+	 */
+	public function billingCycleAnchor($anchor)
+	{
+		$this->billingCycleAnchor = $anchor;
+
+		return $this;
 	}
 
 	/**

--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -123,8 +123,9 @@ class StripeGateway {
 		$payload = [
 			'plan' => $this->plan, 'prorate' => $this->prorate,
 			'quantity' => $this->quantity, 'trial_end' => $this->getTrialEndForUpdate(),
-			'billing_cycle_anchor' => $this->billingCycleAnchor
 		];
+
+		if($this->billingCycleAnchor) array_push($payload, ['billing_cycle_anchor' => $this->billingCycleAnchor]);
 
 		if ($this->coupon) $payload['coupon'] = $this->coupon;
 
@@ -191,7 +192,7 @@ class StripeGateway {
 	 */
 	public function resume($token = null)
 	{
-		$this->noProrate()->skipTrial()->create($token, [], $this->getStripeCustomer());
+		$this->noProrate()->billingCycleAnchor(null)->skipTrial()->create($token, [], $this->getStripeCustomer());
 
 		$this->billable->setTrialEndDate(null)->saveBillableInstance();
 	}

--- a/tests/InvoiceTest.php
+++ b/tests/InvoiceTest.php
@@ -60,8 +60,10 @@ class InvoiceTest extends PHPUnit_Framework_TestCase {
 	public function testDiscountCanBeRetrieved()
 	{
 		$invoice = new Invoice($billable = m::mock('Laravel\Cashier\BillableInterface'), (object) ['total' => 10000, 'subtotal' => 20000, 'currency' => 'usd']);
+
 		$billable->shouldReceive('addCurrencySymbol')->andReturn('$100');
 		$billable->shouldReceive('getCurrencyLocale')->andReturn('en_US');
+
 		$this->assertEquals(100.00, $invoice->discount());
 		$this->assertEquals('$100', $invoice->discountCurrency());
 	}

--- a/tests/StripeGatewayTest.php
+++ b/tests/StripeGatewayTest.php
@@ -22,8 +22,7 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 			'plan' => 'plan',
 			'prorate' => true,
 			'quantity' => 1,
-			'trial_end' => null,
-			'billing_cycle_anchor' => null
+			'trial_end' => null
 		])->andReturn((object) ['id' => 'sub_id']);
 		$customer->id = 'foo';
 		$billable->shouldReceive('setStripeSubscription')->once()->with('sub_id');
@@ -44,8 +43,7 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 			'plan' => 'plan',
 			'prorate' => true,
 			'quantity' => 1,
-			'trial_end' => 'now',
-			'billing_cycle_anchor' => null
+			'trial_end' => 'now'
 		])->andReturn((object) ['id' => 'sub_id']);
 		$customer->id = 'foo';
 		$billable->shouldReceive('setStripeSubscription')->once()->with('sub_id');

--- a/tests/StripeGatewayTest.php
+++ b/tests/StripeGatewayTest.php
@@ -23,6 +23,7 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 			'prorate' => true,
 			'quantity' => 1,
 			'trial_end' => null,
+			'billing_cycle_anchor' => null
 		])->andReturn((object) ['id' => 'sub_id']);
 		$customer->id = 'foo';
 		$billable->shouldReceive('setStripeSubscription')->once()->with('sub_id');
@@ -44,6 +45,7 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 			'prorate' => true,
 			'quantity' => 1,
 			'trial_end' => 'now',
+			'billing_cycle_anchor' => null
 		])->andReturn((object) ['id' => 'sub_id']);
 		$customer->id = 'foo';
 		$billable->shouldReceive('setStripeSubscription')->once()->with('sub_id');
@@ -106,7 +108,7 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 		$customer->shouldReceive('updateSubscription')->once()->with([
 			'plan' => 1,
 			'quantity' => 5,
-			'trial_end' => 'now',
+			'trial_end' => 'now'
 		]);
 
 		$gateway = new StripeGateway($this->mockBillableInterface(), 'plan');
@@ -122,7 +124,7 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 		$customer->shouldReceive('updateSubscription')->once()->with([
 			'plan' => 1,
 			'quantity' => 5,
-			'trial_end' => 'now',
+			'trial_end' => 'now'
 		]);
 
 		$gateway = new StripeGateway($this->mockBillableInterface(), 'plan');


### PR DESCRIPTION
Usage example:

$user->subscription("standard")->noProrate()->billingCycleAnchor("now")->swapAndInvoice();

## Stripe Internal Documentation

At creation time, passing a non-now value for billing_cycle_anchor allows you to set up a subscription to have its first "regular" billing date be at a specified point in the future. In particular (and unlike trial_end) billing_cycle_anchor lets you make a prorated charge for a fraction of the month, and then "snap" the billing cycle to the day that you desire.

So, for instance, if on the 20th of January you did a create subscription request with billing_cycle_anchor equal to February 1st, your customer would immediately be charged for about 1/3 of a month, and then subsequently be charged the full amount on the 1st of each month, going forward.

Additionally, when updating an existing subscription, you can pass billing_cycle_anchor=now (you can pass the string "now", just like for trial_end) to force the billing cycle to "reset" and be anchored "now", the way that it would if you were changing intervals.

Concretely, if you had a subscription that billed on the 1st of the month and then on the 18th of February you made an update request with billing_cycle_anchor=now, the subscription would immediately bill in full for the month of February 18th - March 18th, and then bill on the 18th of the month going forward.