### PR TITLE
General charges on a customer (one time purchases)

### DIFF
--- a/src/Laravel/Cashier/BillableTrait.php
+++ b/src/Laravel/Cashier/BillableTrait.php
@@ -17,7 +17,7 @@ trait BillableTrait {
 	/**
 	 * Manipulate a card or a card in storage.
 	 * 
-	 * @param  string|null $token
+	 * @param  string|null  $token
 	 * @return \Laravel\Cashier\StripeGateway
 	 */
 	public function card($token = null) {

--- a/src/Laravel/Cashier/BillableTrait.php
+++ b/src/Laravel/Cashier/BillableTrait.php
@@ -18,7 +18,7 @@ trait BillableTrait {
 	 * Manipulate a card or a card in storage.
 	 * 
 	 * @param  string|null $token
-	 * @return Laravel\Cashier\StripeGateway
+	 * @return \Laravel\Cashier\StripeGateway
 	 */
 	public function card($token = null) {
 

--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -1,7 +1,7 @@
 <?php namespace Laravel\Cashier;
 
 use Carbon\Carbon;
-use Stripe_Invoice, Stripe_Customer, Stripe_Charge, Stripe_CardError;
+use Stripe_Invoice, Stripe_Customer, Stripe_Charge;
 
 class StripeGateway {
 
@@ -111,7 +111,7 @@ class StripeGateway {
 		{
 			$charge = Stripe_Charge::create($properties);
 		}
-		catch(Stripe_CardError $e) 
+		catch(\Stripe_CardError $e)
 		{
 			// The card on the account was declined.
 

--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -1,7 +1,7 @@
 <?php namespace Laravel\Cashier;
 
 use Carbon\Carbon;
-use Stripe_Invoice, Stripe_Customer, Stripe_Charge;
+use Stripe_Invoice, Stripe_Customer, Stripe_Charge, Stripe_CardError;
 
 class StripeGateway {
 


### PR DESCRIPTION
As a remake of #96, this will introduce general charges on a given card or customer aka one time purchases.

```php
$user = Auth::user();
$token = Input::get('stripeToken');

$user->card($token)
     ->charge([
         "amount" => 1500,
         "currency" => "usd",

         // additional properties...
     ]);
```

If you omit the token, it will try an search for a card stored on the customer object else throw an exception. When a charge is successful, it will return a charge object that you can catch and store. 

If a customer doesn't exist, it will create the customer with/without a card. If without a card, it will store the customer as well as throw an exception once a charge is made without a card. 

charge() takes an optional second parameter for defining user properties.