### PR TITLE
[Proposal] invoicePath method

### DIFF
--- a/src/Laravel/Cashier/Billable.php
+++ b/src/Laravel/Cashier/Billable.php
@@ -108,7 +108,7 @@ trait Billable {
 	 *
 	 * @param  string  $id
 	 * @param  array   $data
-	 * @return \Symfony\Component\HttpFoundation\Response
+	 * @return string
 	 */
 	public function invoicePath($id, array $data)
 	{

--- a/src/Laravel/Cashier/Billable.php
+++ b/src/Laravel/Cashier/Billable.php
@@ -104,6 +104,18 @@ trait Billable {
 	}
 
 	/**
+	 * Get the local path of an invoice.
+	 *
+	 * @param  string  $id
+	 * @param  array   $data
+	 * @return \Symfony\Component\HttpFoundation\Response
+	 */
+	public function invoicePath($id, array $data)
+	{
+		return $this->findInvoiceOrFail($id)->getInvoicePath($data);
+	}
+
+	/**
 	 * Get an array of the entity's invoices.
 	 *
 	 * @param  array  $parameters

--- a/src/Laravel/Cashier/Invoice.php
+++ b/src/Laravel/Cashier/Invoice.php
@@ -277,7 +277,7 @@ class Invoice {
 	 *
 	 * @param  array   $data
 	 * @param  string  $storagePath
-	 * @return \Symfony\Component\HttpFoundation\Response
+	 * @return string
 	 */
 	public function getInvoicePath(array $data, $storagePath = null)
 	{

--- a/src/Laravel/Cashier/Invoice.php
+++ b/src/Laravel/Cashier/Invoice.php
@@ -273,6 +273,20 @@ class Invoice {
 	}
 
 	/**
+	 * Get the local path of an invoice.
+	 *
+	 * @param  array   $data
+	 * @param  string  $storagePath
+	 * @return \Symfony\Component\HttpFoundation\Response
+	 */
+	public function getInvoicePath(array $data, $storagePath = null)
+	{
+		$filename = $this->getDownloadFilename($data['product']);
+
+		return $this->writeInvoice($data, $storagePath);
+	}
+
+	/**
 	 * Create an invoice download response.
 	 *
 	 * @param  array   $data


### PR DESCRIPTION
I haven't found any way to get the path for an invoice so with the `invoicePath` method the local path for an invoice can be retrieved which then can be used to attach the invoice to an email or whatever else needs to be done with it.

```php
$invoice = $user->invoicePath($id, [
    'vendor'  => env('SERVICE_NAME'),
    'product' => $plan['name'],
]);

$billingMailer->send($user, $invoice);
```