### PR TITLE
Update CashierServiceProvider.php

### DIFF
--- a/src/Laravel/Cashier/CashierServiceProvider.php
+++ b/src/Laravel/Cashier/CashierServiceProvider.php
@@ -11,7 +11,7 @@ class CashierServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->loadViewsFrom('cashier', __DIR__.'/../../views');
+		$this->loadViewsFrom(__DIR__.'/../../views', 'cashier');
 	}
 
 	/**


### PR DESCRIPTION
Since Illuminate\Support\ServiceProvider method loadViewsFrom($path, $namespace) accepts first the path and then the namespace, shouldn't these arguments switch places?