### PR TITLE
Creating new card API change

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -451,7 +451,7 @@ class StripeGateway
     {
         $customer = $this->getStripeCustomer();
 
-        $card = $customer->cards->create(['card' => $token]);
+        $card = $customer->sources->create(['card' => $token]);
 
         $customer->default_card = $card->id;
 

--- a/tests/StripeGatewayTest.php
+++ b/tests/StripeGatewayTest.php
@@ -177,8 +177,8 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 		$gateway->shouldReceive('getStripeCustomer')->andReturn($customer = m::mock('StdClass'));
 		$gateway->shouldReceive('getLastFourCardDigits')->once()->andReturn('1111');
 		$customer->subscription = (object) ['plan' => (object) ['id' => 1]];
-		$customer->cards = m::mock('StdClass');
-		$customer->cards->shouldReceive('create')->once()->with(['card' => 'token'])->andReturn($card = m::mock('StdClass'));
+		$customer->sources = m::mock('StdClass');
+		$customer->sources->shouldReceive('create')->once()->with(['card' => 'token'])->andReturn($card = m::mock('StdClass'));
 		$card->id = 'card_id';
 		$customer->shouldReceive('save')->once();
 


### PR DESCRIPTION
Stripe API change: https://stripe.com/docs/upgrades#2015-02-18

There is still an issue with setting (and getting) the last four digits, as the way you retrieve a card is much different than before https://stripe.com/docs/api#retrieve_card

Relevant Stack Overflow issue: http://stackoverflow.com/questions/28735182/laravel-cashier-trouble-updating-card-fatal-error?noredirect=1#comment45864842_28735182