### PR TITLE
Fix docblock to show correct return type.

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -514,7 +514,7 @@ class StripeGateway
      *
      * @param  string  $token
      * @param  array   $properties
-     * @return string
+     * @return \Stripe_Customer
      */
     public function createStripeCustomer($token, array $properties = array())
     {


### PR DESCRIPTION
`createStripeCustomer` returns the result of `getStripeCustomer` and because `getStripeCustomer` returns a `Stripe_Customer` then `createStripeCustomer` does the same.