### PR TITLE
[Proposal] Change cancellation webhook to correct hook from Stripe API

### DIFF
--- a/src/Laravel/Cashier/WebhookController.php
+++ b/src/Laravel/Cashier/WebhookController.php
@@ -50,33 +50,20 @@ class WebhookController extends Controller
     }
 
     /**
-     * Handle a failed payment from a Stripe subscription.
+     * Handle a cancelled customer from a Stripe subscription.
      *
      * @param  array  $payload
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    protected function handleInvoicePaymentFailed(array $payload)
+    protected function handleCustomerSubscriptionDeleted(array $payload)
     {
-        if ($this->tooManyFailedPayments($payload)) {
-            $billable = $this->getBillable($payload['data']['object']['customer']);
+        $billable = $this->getBillable($payload['data']['object']['customer']);
 
-            if ($billable) {
-                $billable->subscription()->cancel();
-            }
+        if ($billable) {
+            $billable->subscription()->cancel();
         }
-
+        
         return new Response('Webhook Handled', 200);
-    }
-
-    /**
-     * Determine if the invoice has too many failed attempts.
-     *
-     * @param  array  $payload
-     * @return bool
-     */
-    protected function tooManyFailedPayments(array $payload)
-    {
-        return $payload['data']['object']['attempt_count'] > 3;
     }
 
     /**


### PR DESCRIPTION
So I'm not sure if this is because of the latest Stripe API changes - or if it has always been this way - but the webhook that Cashier is currently using the handle cancelled subscriptions is not ideal.

The problem is Cashier is currently looking for a `invoice.payment_failed` webhook, which occurs anytime a payment fails. Cashier then manually checks if the payment fails 3 times, then Cashier cancels the subscription *and assumes that Stripe has also cancelled the subscription*.

The problem is there are instances where Stripe could cancel a subscription at other times, or you configure Stripe to cancel after X attempts, not necessarily 3.

It makes more sense to default the webhook to `customer.subscription.deleted`. This way - for any reason - if Stripe cancels a subscription - then that is reflected in our application - regardless of the circumstances.