### PR TITLE
Discount can't be null if it has a discount

### DIFF
--- a/src/Laravel/Cashier/Invoice.php
+++ b/src/Laravel/Cashier/Invoice.php
@@ -139,7 +139,7 @@ class Invoice
      */
     public function hasDiscount()
     {
-        return $this->subtotal > 0 && $this->subtotal != $this->total;
+        return $this->subtotal > 0 && $this->subtotal != $this->total && ! is_null($this->discount);
     }
 
     /**


### PR DESCRIPTION
Amended as per #154 

Checking whether an invoice has a discount is inaccurate when an invoice has tax applied as the sub total and total do not match. This will resolve the issue, or a check for if the subtotal + tax equals the total would work too.