### PR TITLE
Added tax percent method to Billable trait

### DIFF
--- a/src/Laravel/Cashier/Billable.php
+++ b/src/Laravel/Cashier/Billable.php
@@ -493,7 +493,7 @@ trait Billable
      * @return mixed
      */
     public function getTaxPercent() {
-        return null;
+        return;
     }
 
     /**

--- a/src/Laravel/Cashier/Billable.php
+++ b/src/Laravel/Cashier/Billable.php
@@ -488,6 +488,15 @@ trait Billable
     }
 
     /**
+     * Get the percentage tax to apply to subscription
+     *
+     * @return mixed
+     */
+    public function getTaxPercent() {
+        return null;
+    }
+
+    /**
      * Format the given currency for display, without the currency symbol.
      *
      * @param  int  $amount

--- a/src/Laravel/Cashier/Billable.php
+++ b/src/Laravel/Cashier/Billable.php
@@ -493,7 +493,7 @@ trait Billable
      * @return mixed
      */
     public function getTaxPercent() {
-        return;
+        //
     }
 
     /**

--- a/src/Laravel/Cashier/Contracts/Billable.php
+++ b/src/Laravel/Cashier/Contracts/Billable.php
@@ -204,6 +204,13 @@ interface Billable
     public function getCurrencyLocale();
 
     /**
+     * Get the percentage tax to apply to subscription
+     *
+     * @return mixed
+     */
+    public function getTaxPercent();
+
+    /**
      * Format the given currency for display, without the currency symbol.
      *
      * @param  int  $amount

--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -152,6 +152,7 @@ class StripeGateway
         $payload = [
             'plan' => $this->plan, 'prorate' => $this->prorate,
             'quantity' => $this->quantity, 'trial_end' => $this->getTrialEndForUpdate(),
+            'tax_percent' => $this->billable->getTaxPercent()
         ];
 
         return $payload;

--- a/tests/BillableTraitTest.php
+++ b/tests/BillableTraitTest.php
@@ -134,6 +134,22 @@ class BillableTraitTest extends PHPUnit_Framework_TestCase {
 	}
 
 
+    public function testTaxPercentNullByDefault()
+    {
+        $billable = new BillableTraitTestStub;
+        $taxPercent = $billable->getTaxPercent();
+        $this->assertNull($taxPercent);
+    }
+
+
+    public function testTaxPercentCanBeOverridden()
+    {
+        $billable = new BillableTraitTaxTestStub;
+        $taxPercent = $billable->getTaxPercent();
+        $this->assertEquals(20, $taxPercent);
+    }
+
+
 	public function testGettingStripeKey()
 	{
 		Config::shouldReceive('get')->once()->with('services.stripe.secret')->andReturn('foo');
@@ -146,6 +162,13 @@ class BillableTraitTestStub implements Laravel\Cashier\Contracts\Billable {
 	use Laravel\Cashier\Billable;
 	public $cardUpFront = false;
 	public function save() {}
+}
+
+class BillableTraitTaxTestStub implements Laravel\Cashier\Contracts\Billable {
+    use Laravel\Cashier\Billable;
+    public $cardUpFront = false;
+    public function getTaxPercent() {return 20;}
+    public function save() {}
 }
 
 class BillableTraitCardUpFrontTestStub implements Laravel\Cashier\Contracts\Billable {

--- a/tests/StripeGatewayTest.php
+++ b/tests/StripeGatewayTest.php
@@ -23,6 +23,7 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 			'prorate' => true,
 			'quantity' => 1,
 			'trial_end' => null,
+            'tax_percent' => 20
 		])->andReturn((object) ['id' => 'sub_id']);
 		$customer->id = 'foo';
 		$billable->shouldReceive('setStripeSubscription')->once()->with('sub_id');
@@ -44,6 +45,7 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 			'prorate' => true,
 			'quantity' => 1,
 			'trial_end' => 'now',
+            'tax_percent' => 20
 		])->andReturn((object) ['id' => 'sub_id']);
 		$customer->id = 'foo';
 		$billable->shouldReceive('setStripeSubscription')->once()->with('sub_id');
@@ -273,7 +275,8 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 	protected function mockBillableInterface()
 	{
 		$billable = m::mock('Laravel\Cashier\Contracts\Billable');
-		$billable->shouldReceive('getStripeKey')->andReturn('key');
+        $billable->shouldReceive('getStripeKey')->andReturn('key');
+        $billable->shouldReceive('getTaxPercent')->andReturn(20);
 		return $billable;
 	}
 

--- a/tests/StripeGatewayTest.php
+++ b/tests/StripeGatewayTest.php
@@ -23,7 +23,7 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 			'prorate' => true,
 			'quantity' => 1,
 			'trial_end' => null,
-            'tax_percent' => 20
+			'tax_percent' => 20
 		])->andReturn((object) ['id' => 'sub_id']);
 		$customer->id = 'foo';
 		$billable->shouldReceive('setStripeSubscription')->once()->with('sub_id');
@@ -45,7 +45,7 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 			'prorate' => true,
 			'quantity' => 1,
 			'trial_end' => 'now',
-            'tax_percent' => 20
+			'tax_percent' => 20
 		])->andReturn((object) ['id' => 'sub_id']);
 		$customer->id = 'foo';
 		$billable->shouldReceive('setStripeSubscription')->once()->with('sub_id');
@@ -275,8 +275,8 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 	protected function mockBillableInterface()
 	{
 		$billable = m::mock('Laravel\Cashier\Contracts\Billable');
-        $billable->shouldReceive('getStripeKey')->andReturn('key');
-        $billable->shouldReceive('getTaxPercent')->andReturn(20);
+		$billable->shouldReceive('getStripeKey')->andReturn('key');
+		$billable->shouldReceive('getTaxPercent')->andReturn(20);
 		return $billable;
 	}
 


### PR DESCRIPTION
A user can now override the `getTaxPercent()` method to provide a
percentage tax to stripe. Implemented as a method so that it can be
calculated on a per-user basis