### PR TITLE
Use getCurrency instead of usd

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -87,7 +87,7 @@ class StripeGateway
     public function charge($amount, array $options = [])
     {
         $options = array_merge([
-            'currency' => 'usd',
+            'currency' => $this->getCurrency(),
         ], $options);
 
         $options['amount'] = $amount;


### PR DESCRIPTION
Use the getCurrency function instead of hardcoding usd.
Had a suprise when I tried to charge my clients.