### PR TITLE
Allow testing of Webhooks

### DIFF
--- a/feajvkhr.ict.txt
+++ b/feajvkhr.ict.txt
@@ -1,0 +1,11 @@
+﻿Squash
+
+# Please enter the commit message for your changes. Lines starting
+# with '#' will be ignored, and an empty message aborts the commit.
+# On branch patch-1
+# Your branch is up-to-date with 'origin/patch-1'.
+#
+# Changes to be committed:
+#	new file:   tcqlgxpx.0fv.txt
+#
+

--- a/src/Laravel/Cashier/WebhookController.php
+++ b/src/Laravel/Cashier/WebhookController.php
@@ -21,8 +21,10 @@ class WebhookController extends Controller
     {
         $payload = $this->getJsonPayload();
 
-        if (! $this->eventExistsOnStripe($payload['id'])) {
-            return;
+        if (! Config::get('app.debug')) {
+            if (! $this->eventExistsOnStripe($payload['id'])) {
+                return;
+            }
         }
 
         $method = 'handle'.studly_case(str_replace('.', '_', $payload['type']));

--- a/src/Laravel/Cashier/WebhookController.php
+++ b/src/Laravel/Cashier/WebhookController.php
@@ -1,6 +1,5 @@
 <?php namespace Laravel\Cashier;
 
-use Config;
 use Exception;
 use Stripe\Event as StripeEvent;
 use Illuminate\Routing\Controller;

--- a/src/Laravel/Cashier/WebhookController.php
+++ b/src/Laravel/Cashier/WebhookController.php
@@ -21,7 +21,7 @@ class WebhookController extends Controller
     {
         $payload = $this->getJsonPayload();
 
-        if (! Config::get('app.debug')) {
+        if (! Config::get('services.stripe.debug')) {
             if (! $this->eventExistsOnStripe($payload['id'])) {
                 return;
             }

--- a/src/Laravel/Cashier/WebhookController.php
+++ b/src/Laravel/Cashier/WebhookController.php
@@ -6,6 +6,7 @@ use Stripe\Event as StripeEvent;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Config;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 

--- a/tcqlgxpx.0fv.txt
+++ b/tcqlgxpx.0fv.txt
@@ -1,0 +1,26 @@
+﻿squash 2ded8c5 Update WebhookController.php
+squash 990df17 Update WebhookController.php
+squash c8bfa31 Update WebhookController.php
+squash 7d88e03 Update WebhookController.php
+squash 4643246 Update WebhookControllerTest.php
+squash cff0e51 Update WebhookControllerTest.php
+squash bc3cf09 Update WebhookControllerTest.php
+
+# Rebase 07b7cad..bc3cf09 onto 07b7cad
+#
+# Commands:
+#  p, pick = use commit
+#  r, reword = use commit, but edit the commit message
+#  e, edit = use commit, but stop for amending
+#  s, squash = use commit, but meld into previous commit
+#  f, fixup = like "squash", but discard this commit's log message
+#  x, exec = run command (the rest of the line) using shell
+#
+# These lines can be re-ordered; they are executed from top to bottom.
+#
+# If you remove a line here THAT COMMIT WILL BE LOST.
+#
+# However, if you remove everything, the rebase will be aborted.
+#
+# Note that empty commits are commented out
+

--- a/tests/WebhookControllerTest.php
+++ b/tests/WebhookControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Config;
 
 class WebhookControllerTest extends PHPUnit_Framework_TestCase {
 

--- a/tests/WebhookControllerTest.php
+++ b/tests/WebhookControllerTest.php
@@ -16,6 +16,7 @@ class WebhookControllerTest extends PHPUnit_Framework_TestCase {
 		$_SERVER['__received'] = false;
 		Request::shouldReceive('getContent')->andReturn(json_encode(['type' => 'charge.succeeded', 'id' => 'event-id']));
 		$controller = new WebhookControllerTestStub;
+		Config::shouldReceive('get')->once()->with('services.stripe.debug')->andReturn(false);
 		$controller->handleWebhook();
 
 		$this->assertTrue($_SERVER['__received']);

--- a/tests/WebhookControllerTest.php
+++ b/tests/WebhookControllerTest.php
@@ -15,8 +15,8 @@ class WebhookControllerTest extends PHPUnit_Framework_TestCase {
 	{
 		$_SERVER['__received'] = false;
 		Request::shouldReceive('getContent')->andReturn(json_encode(['type' => 'charge.succeeded', 'id' => 'event-id']));
-		$controller = new WebhookControllerTestStub;
 		Config::shouldReceive('get')->once()->with('services.stripe.debug')->andReturn(false);
+		$controller = new WebhookControllerTestStub;
 		$controller->handleWebhook();
 
 		$this->assertTrue($_SERVER['__received']);
@@ -26,6 +26,7 @@ class WebhookControllerTest extends PHPUnit_Framework_TestCase {
 	public function testNormalResponseIsReturnedIfMethodIsMissing()
 	{
 		Request::shouldReceive('getContent')->andReturn(json_encode(['type' => 'foo.bar', 'id' => 'event-id']));
+		Config::shouldReceive('get')->once()->with('services.stripe.debug')->andReturn(false);
 		$controller = new WebhookControllerTestStub;
 		$response = $controller->handleWebhook();
 		$this->assertEquals(200, $response->getStatusCode());


### PR DESCRIPTION
The issue is that you cannot test Stripe Webhooks because of the brute force protection.  The test event from Stripe.com has an id of evt_00000000000000 which obviously cannot be validated.  This makes it impossible to test.  

So if in debug mode allow this protection to be bypassed.  Or maybe add in a services.stripe.testing or something like that.