### PR TITLE
Fixing tax_percent issue

### DIFF
--- a/src/Laravel/Cashier/Billable.php
+++ b/src/Laravel/Cashier/Billable.php
@@ -491,11 +491,11 @@ trait Billable
     /**
      * Get the tax percentage to apply to the subscription.
      *
-     * @return mixed
+     * @return int
      */
     public function getTaxPercent()
     {
-        //
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Stripe throwns an error when tax_percent is empty ( Invalid decimal: ; must contain at maximum two decimal places ), let's default it to 0.