### PR TITLE
Fixing tax_percent issue

### DIFF
--- a/src/Laravel/Cashier/Billable.php
+++ b/src/Laravel/Cashier/Billable.php
@@ -491,11 +491,11 @@ trait Billable
     /**
      * Get the tax percentage to apply to the subscription.
      *
-     * @return mixed
+     * @return int
      */
     public function getTaxPercent()
     {
-        //
+        return 0;
     }
 
     /**

--- a/src/Laravel/Cashier/Contracts/Billable.php
+++ b/src/Laravel/Cashier/Contracts/Billable.php
@@ -206,7 +206,7 @@ interface Billable
     /**
      * Get the tax percentage to apply to the subscription.
      *
-     * @return mixed
+     * @return int
      */
     public function getTaxPercent();
 

--- a/tests/BillableTraitTest.php
+++ b/tests/BillableTraitTest.php
@@ -134,11 +134,11 @@ class BillableTraitTest extends PHPUnit_Framework_TestCase {
 	}
 
 
-    public function testTaxPercentNullByDefault()
+    public function testTaxPercentZeroByDefault()
     {
         $billable = new BillableTraitTestStub;
         $taxPercent = $billable->getTaxPercent();
-        $this->assertNull($taxPercent);
+        $this->assertEquals(0, $taxPercent);
     }
 
 


### PR DESCRIPTION
Stripe throwns an error when tax_percent is empty ( Invalid decimal: ; must contain at maximum two decimal places ), let's default it to 0.