### PR TITLE
newQuantity

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -349,6 +349,19 @@ class StripeGateway
 
         $this->updateQuantity($customer, $customer->subscription->quantity - $count);
     }
+    
+    /**
+     * Set the new quantity of the subscription.
+     *
+     * @param  int  $quantity
+     * @return void
+     */
+    public function newQuantity($quantity)
+    {
+        $customer = $this->getStripeCustomer();
+
+        $this->updateQuantity($customer, $quantity);
+    }
 
     /**
      * Update the quantity of the subscription.


### PR DESCRIPTION
There is no easy way to set a new Quantity on a subscription. Currently the only choices are `increment` and `decrement` - but that assumes you want to only increase/decrease from a previous known amount. 

There are useful times where you just want to set a specific quantity - regardless of any previous number.

Before the pull you could do this:

```
$user->subscription()->updateQuntity($user->subscription()->getStripeCustomer(), 10);
```

Now you can just do

```
$user->subscription()->newQuantity(10);
```

