### PR TITLE
[Bug] Subscription update provides "Invalid integer"

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -151,8 +151,12 @@ class StripeGateway
     {
         $payload = [
             'plan' => $this->plan, 'prorate' => $this->prorate,
-            'quantity' => $this->quantity, 'trial_end' => $this->getTrialEndForUpdate(),
+            'quantity' => $this->quantity
         ];
+
+        if ($trialEnd = $this->getTrialEndForUpdate()) {
+            $payload['trial_end'] = $trialEnd;
+        }
 
         if ($taxPercent = $this->billable->getTaxPercent()) {
             $payload['tax_percent'] = $taxPercent;

--- a/tests/StripeGatewayTest.php
+++ b/tests/StripeGatewayTest.php
@@ -22,7 +22,6 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase {
 			'plan' => 'plan',
 			'prorate' => true,
 			'quantity' => 1,
-			'trial_end' => null,
 			'tax_percent' => 20
 		])->andReturn((object) ['id' => 'sub_id']);
 		$customer->id = 'foo';


### PR DESCRIPTION
Subscription update provides "Invalid integer" message if 'trial_end' is set to null. Making 'trial_end' optional