### PR TITLE
Load StripeGateway from the container

### DIFF
--- a/src/Laravel/Cashier/Billable.php
+++ b/src/Laravel/Cashier/Billable.php
@@ -55,7 +55,7 @@ trait Billable
      */
     public function subscription($plan = null)
     {
-        return new StripeGateway($this, $plan);
+        return app('Laravel\Cashier\StripeGateway', [$this, $plan]);
     }
 
     /**


### PR DESCRIPTION
Loading the Laravel\Cashier\StripeGateway from the containers allows to mock it in functional test.

While trying to test the user registration + subscription process, you might not want to hit the stripe API.