### PR TITLE
Allow testing of Webhooks using ENV

### DIFF
--- a/src/Laravel/Cashier/WebhookController.php
+++ b/src/Laravel/Cashier/WebhookController.php
@@ -50,7 +50,7 @@ class WebhookController extends Controller
     }
 
     /**
-     * Check if testing mode is on
+     * Verify if cashier is in testing mode.
      * 
      * @return bool
      */

--- a/src/Laravel/Cashier/WebhookController.php
+++ b/src/Laravel/Cashier/WebhookController.php
@@ -21,7 +21,7 @@ class WebhookController extends Controller
     {
         $payload = $this->getJsonPayload();
 
-        if (! $this->eventExistsOnStripe($payload['id'])) {
+        if (! $this->eventExistsOnStripe($payload['id']) && ! $this->isInTestingMode()) {
             return;
         }
 
@@ -47,6 +47,16 @@ class WebhookController extends Controller
         } catch (Exception $e) {
             return false;
         }
+    }
+
+    /**
+     * Check if testing mode is on
+     * 
+     * @return bool
+     */
+    protected function isInTestingMode()
+    {
+        return (bool) getenv('CASHIER_TESTING');
     }
 
     /**


### PR DESCRIPTION
After seeing the pull request #190 I wanted to contribute with what looks to me a better solution.

As @taylorotwell said using environment variables looked like a better choice.

To keep it simple I added a isInTestingMode method that return a boolean according to the CASHIER_TESTING env variable.

Then in the handleWebhook method we can verify that we are not in testing mode.