### PR TITLE
Added deleted check for getStripeCustomer

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -551,7 +551,7 @@ class StripeGateway
     {
         $customer = Customer::retrieve($id ?: $this->billable->getStripeId(), $this->getStripeKey());
 
-        if ($customer->deleted === false && $this->usingMultipleSubscriptionApi($customer)) {
+        if (!isset($customer->deleted) && $this->usingMultipleSubscriptionApi($customer)) {
             $customer->subscription = $customer->findSubscription($this->billable->getStripeSubscription());
         }
 

--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -551,7 +551,7 @@ class StripeGateway
     {
         $customer = Customer::retrieve($id ?: $this->billable->getStripeId(), $this->getStripeKey());
 
-        if ($this->usingMultipleSubscriptionApi($customer)) {
+        if ($customer->deleted === false && $this->usingMultipleSubscriptionApi($customer)) {
             $customer->subscription = $customer->findSubscription($this->billable->getStripeSubscription());
         }
 

--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -551,7 +551,7 @@ class StripeGateway
     {
         $customer = Customer::retrieve($id ?: $this->billable->getStripeId(), $this->getStripeKey());
 
-        if (!isset($customer->deleted) && $this->usingMultipleSubscriptionApi($customer)) {
+        if (! isset($customer->deleted) && $this->usingMultipleSubscriptionApi($customer)) {
             $customer->subscription = $customer->findSubscription($this->billable->getStripeSubscription());
         }
 


### PR DESCRIPTION
Added a check to make sure customers are not deleted before proceeding to find an existing subscription. `Customer::usingMultipleSubscriptionApi()` will cause an error as Customer::subscriptions does not exist for deleted models. Deleted customers do not have existing subscriptions so proceeding to find a subscription is not necessary.

The error is Stripe Notice: Undefined property of Laravel\Cashier\Customer instance: subscriptions