### PR TITLE
[Proposal] Allow multiple models

### DIFF
--- a/src/Laravel/Cashier/EloquentBillableRepository.php
+++ b/src/Laravel/Cashier/EloquentBillableRepository.php
@@ -15,9 +15,19 @@ class EloquentBillableRepository implements BillableRepositoryInterface
      */
     public function find($stripeId)
     {
-        $model = $this->createCashierModel(Config::get('services.stripe.model'));
+        $billableModels = Config::get('services.stripe.model');
 
-        return $model->where($model->getStripeIdName(), $stripeId)->first();
+        if (!is_array($billableModels)) {
+            $billableModels = [$billableModels];
+        }
+
+        foreach ($billableModels as $billableModel) {
+            $model = $this->createCashierModel($billableModel);
+
+            if ($result = $model->where($model->getStripeIdName(), $stripeId)->first()) {
+                return $result;
+            }
+        }
     }
 
     /**

--- a/src/Laravel/Cashier/EloquentBillableRepository.php
+++ b/src/Laravel/Cashier/EloquentBillableRepository.php
@@ -17,7 +17,7 @@ class EloquentBillableRepository implements BillableRepositoryInterface
     {
         $billableModels = Config::get('services.stripe.model');
 
-        if (!is_array($billableModels)) {
+        if (! is_array($billableModels)) {
             $billableModels = [$billableModels];
         }
 
@@ -28,8 +28,6 @@ class EloquentBillableRepository implements BillableRepositoryInterface
                 return $result;
             }
         }
-
-        return null;
     }
 
     /**

--- a/src/Laravel/Cashier/EloquentBillableRepository.php
+++ b/src/Laravel/Cashier/EloquentBillableRepository.php
@@ -28,6 +28,8 @@ class EloquentBillableRepository implements BillableRepositoryInterface
                 return $result;
             }
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Currently only one model with a billable interface works. This allows the `services.stripe.model` config setting to be either a string with a single model or an array of models.

I know it's rare to use multiple models with Cashier, but I'm working on a project right now where customers can have subscriptions on either individual listings or their account.