### PR TITLE
Adding support for billing_cycle_anchor

### DIFF
--- a/src/Laravel/Cashier/StripeGateway.php
+++ b/src/Laravel/Cashier/StripeGateway.php
@@ -67,8 +67,8 @@ class StripeGateway
     /**
      * Indicates the plan's billing cycle anchor.
      * Can be 'now', 'unchanged', or a Carbon date.
-     * Currently, an undocumented, but useful feature.
-     * See https://groups.google.com/a/lists.stripe.com/forum/#!msg/api-discuss/PsKhHPI7XIQ/viyqVPNwplYJ
+     * Currently, it's an undocumented feature.
+     * See https://groups.google.com/a/lists.stripe.com/forum/#!msg/api-discuss/PsKhHPI7XIQ/viyqVPNwplYJ for more info.
      *
      * @var string|\Carbon\Carbon
      */

--- a/tests/BillableTraitTest.php
+++ b/tests/BillableTraitTest.php
@@ -150,6 +150,7 @@ class BillableTraitTestStub implements Laravel\Cashier\Contracts\Billable
 {
     use Laravel\Cashier\Billable;
     public $cardUpFront = false;
+
     public function save()
     {
     }
@@ -159,10 +160,12 @@ class BillableTraitTaxTestStub implements Laravel\Cashier\Contracts\Billable
 {
     use Laravel\Cashier\Billable;
     public $cardUpFront = false;
+
     public function getTaxPercent()
     {
         return 20;
     }
+
     public function save()
     {
     }
@@ -172,6 +175,7 @@ class BillableTraitCardUpFrontTestStub implements Laravel\Cashier\Contracts\Bill
 {
     use Laravel\Cashier\Billable;
     public $cardUpFront = true;
+    
     public function save()
     {
     }

--- a/tests/BillableTraitTest.php
+++ b/tests/BillableTraitTest.php
@@ -175,7 +175,7 @@ class BillableTraitCardUpFrontTestStub implements Laravel\Cashier\Contracts\Bill
 {
     use Laravel\Cashier\Billable;
     public $cardUpFront = true;
-    
+
     public function save()
     {
     }

--- a/tests/StripeGatewayTest.php
+++ b/tests/StripeGatewayTest.php
@@ -253,6 +253,64 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($time, $gateway->getTrialEndForCustomer($customer)->getTimestamp());
     }
 
+    public function testgeBillingCycleAnchorForUpdateD()
+    {
+        $billable = $this->mockBillableInterface();
+        $billable->shouldReceive('readyForBilling')->once()->andReturn(true);
+        $gateway = m::mock('Laravel\Cashier\StripeGateway[getStripeCustomer,getTrialEndForCustomer]', [$billable, 'plan']);
+        $gateway->shouldReceive('getStripeCustomer')->once()->andReturn($customer = m::mock('StdClass'));
+        $gateway->shouldReceive('getTrialEndForCustomer')->once()->with($customer)->andReturn(null);
+        $gateway->maintainTrial();
+
+        $this->assertNull($gateway->getTrialFor());
+    }
+
+    public function testCreateWithBillingCycleAnchorSetToNow()
+    {
+        $billable = $this->mockBillableInterface();
+        $billable->shouldReceive('getCurrency')->andReturn('usd');
+
+        $gateway = m::mock('Laravel\Cashier\StripeGateway[getStripeCustomer,createStripeCustomer,updateLocalStripeData]', [$billable, 'plan']);
+        $gateway->shouldReceive('createStripeCustomer')->andReturn($customer = m::mock('StdClass'));
+        $customer->shouldReceive('updateSubscription')->once()->with([
+            'plan' => 'plan',
+            'prorate' => true,
+            'quantity' => 1,
+            'tax_percent' => 20,
+            'billing_cycle_anchor' => 'now'
+        ])->andReturn((object) ['id' => 'sub_id']);
+        $customer->id = 'foo';
+        $billable->shouldReceive('setStripeSubscription')->once()->with('sub_id');
+        $gateway->shouldReceive('getStripeCustomer')->once()->with('foo');
+        $gateway->shouldReceive('updateLocalStripeData')->once();
+
+        $gateway->anchorBillingCycleOn('now');
+        $gateway->create('token', []);
+    }
+
+    public function testCreateWithBillingCycleAnchorSetToDate()
+    {
+        $billable = $this->mockBillableInterface();
+        $billable->shouldReceive('getCurrency')->andReturn('usd');
+        $twoWeeksFromNow = Carbon\Carbon::now()->addWeeks(2);
+        $gateway = m::mock('Laravel\Cashier\StripeGateway[getStripeCustomer,createStripeCustomer,updateLocalStripeData]', [$billable, 'plan']);
+        $gateway->shouldReceive('createStripeCustomer')->andReturn($customer = m::mock('StdClass'));
+        $customer->shouldReceive('updateSubscription')->once()->with([
+            'plan' => 'plan',
+            'prorate' => true,
+            'quantity' => 1,
+            'tax_percent' => 20,
+            'billing_cycle_anchor' => $twoWeeksFromNow->getTimestamp()
+        ])->andReturn((object) ['id' => 'sub_id']);
+        $customer->id = 'foo';
+        $billable->shouldReceive('setStripeSubscription')->once()->with('sub_id');
+        $gateway->shouldReceive('getStripeCustomer')->once()->with('foo');
+        $gateway->shouldReceive('updateLocalStripeData')->once();
+
+        $gateway->anchorBillingCycleOn($twoWeeksFromNow);
+        $gateway->create('token', []);
+    }
+
     protected function mockBillableInterface()
     {
         $billable = m::mock('Laravel\Cashier\Contracts\Billable');

--- a/tests/StripeGatewayTest.php
+++ b/tests/StripeGatewayTest.php
@@ -277,7 +277,7 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase
             'prorate' => true,
             'quantity' => 1,
             'tax_percent' => 20,
-            'billing_cycle_anchor' => 'now'
+            'billing_cycle_anchor' => 'now',
         ])->andReturn((object) ['id' => 'sub_id']);
         $customer->id = 'foo';
         $billable->shouldReceive('setStripeSubscription')->once()->with('sub_id');
@@ -300,7 +300,7 @@ class StripeGatewayTest extends PHPUnit_Framework_TestCase
             'prorate' => true,
             'quantity' => 1,
             'tax_percent' => 20,
-            'billing_cycle_anchor' => $twoWeeksFromNow->getTimestamp()
+            'billing_cycle_anchor' => $twoWeeksFromNow->getTimestamp(),
         ])->andReturn((object) ['id' => 'sub_id']);
         $customer->id = 'foo';
         $billable->shouldReceive('setStripeSubscription')->once()->with('sub_id');


### PR DESCRIPTION
Stripe has an undocumented feature that allows you to anchor the billing cycle to a certain date. What happens is that if you set billing_cycle_anchor Stripe will immediately charge the subscriber a prorated amount of the plan from the sign up date until the billing cycle anchor date, at which point the subscription would charge the full amount. 

Some people implement the feature above by using a trial, but I feel this is a nicer alternative.

Here's some background reading:
https://groups.google.com/a/lists.stripe.com/forum/#!msg/api-discuss/hL8Gn4MypEU/QdLDUDtr-0gJ
and
https://groups.google.com/a/lists.stripe.com/forum/#!searchin/api-discuss/billing_cycle_anchor/api-discuss/PsKhHPI7XIQ/KRgqfw4i4vYJ