### PR TITLE
General fixes, fixes typos, conventions, ignored parameters, etc, fixes #221

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,7 +2,7 @@
 
 ## Version 2.0.4
 
-- Allow user to pass paramaters when fetching invoices.
+- Allow user to pass parameters when fetching invoices.
 - Added a method to get the current subscription period's end date.
 - If a webhook endpoint is not defined for a given hook, an empty 200 response will be returned.
 

--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -8,8 +8,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<style>
 			body {
-				background: #fff;
-				background-image: none;
+				background: #fff none;
 				font-size: 12px;
 			}
 			address{
@@ -25,12 +24,6 @@
 			.invoice-head td {
 				padding: 0 8px;
 			}
-			.invoice-body{
-				background-color:transparent;
-			}
-			.logo {
-				padding-bottom: 10px;
-			}
 			.table th {
 				vertical-align: bottom;
 				font-weight: bold;
@@ -44,9 +37,6 @@
 				text-align: left;
 				vertical-align: top;
 				border-top: 1px solid #dddddd;
-			}
-			.well {
-				margin-top: 15px;
 			}
 	</style>
 </head>

--- a/src/BillableTrait.php
+++ b/src/BillableTrait.php
@@ -11,7 +11,7 @@ use Stripe\Customer as StripeCustomer;
 use Stripe\Error\InvalidRequest as StripeErrorInvalidRequest;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-trait Billable
+trait BillableTrait
 {
     /**
      * The Stripe API key.
@@ -107,7 +107,6 @@ trait Billable
     /**
      * Invoice the billable entity outside of regular billing cycle.
      *
-     * @param  string  $subscription
      * @return bool
      */
     public function invoice()
@@ -161,6 +160,7 @@ trait Billable
      *
      * @param  string  $id
      * @return \Laravel\Cashier\Invoice
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function findInvoiceOrFail($id)
     {
@@ -178,12 +178,11 @@ trait Billable
      *
      * @param  string  $id
      * @param  array   $data
-     * @param  string  $storagePath
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function downloadInvoice($id, array $data, $storagePath = null)
+    public function downloadInvoice($id, array $data)
     {
-        return $this->findInvoiceOrFail($id)->download($data, $storagePath);
+        return $this->findInvoiceOrFail($id)->download($data);
     }
 
     /**
@@ -218,7 +217,6 @@ trait Billable
     /**
      * Get an array of the entity's invoices.
      *
-     * @param  bool  $includePending
      * @param  array  $parameters
      * @return \Illuminate\Support\Collection
      */
@@ -270,7 +268,6 @@ trait Billable
     /**
      * Apply a coupon to the billable entity.
      *
-     * @param  string  $subscription
      * @param  string  $coupon
      * @return void
      */

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -58,7 +58,7 @@ class WebhookController extends Controller
      * Get the billable entity instance by Stripe ID.
      *
      * @param  string  $stripeId
-     * @return \Laravel\Cashier\Contracts\Billable
+     * @return \Laravel\Cashier\BillableTrait
      */
     protected function getUserByStripeId($stripeId)
     {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -90,7 +90,7 @@ class Subscription extends Model
      */
     public function incrementQuantity($count = 1)
     {
-        $this->updateQuantity($this->quantity + 1);
+        $this->updateQuantity($this->quantity + $count);
 
         return $this;
     }
@@ -116,7 +116,7 @@ class Subscription extends Model
      */
     public function decrementQuantity($count = 1)
     {
-        $this->updateQuantity(max(1, $this->quantity - 1));
+        $this->updateQuantity(max(1, $this->quantity - $count));
 
         return $this;
     }

--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -270,7 +270,7 @@ class CashierTest extends PHPUnit_Framework_TestCase
 
 class User extends Eloquent
 {
-    use Laravel\Cashier\Billable;
+    use Laravel\Cashier\BillableTrait;
 }
 
 class CashierTestControllerStub extends WebhookController


### PR DESCRIPTION
- Fix typo in changes.md
- Optimise parameters, remove unused classes from receipt view
- Rename Billable.php to BillableTrait.php in line with set conventions
- Fix phpdoc in a few places
- Use unused parameters, eg. incrementQuantity in Subscription
- Remove unused parameters from methods