### PR TITLE
Relax symfony version constraint a touch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "illuminate/support": "~5.1",
         "nesbot/carbon": "~1.0",
         "stripe/stripe-php": "~3.0",
-        "symfony/http-kernel": "2.7.*|2.8.*|3.0.*"
+        "symfony/http-kernel": "~2.7|~3.0"
     },
     "require-dev": {
         "dompdf/dompdf": "^0.6.1",


### PR DESCRIPTION
Being so strict is unneeded, and a bit silly given we allow usage with laravel 5.3 components which require symfony 3.1's http stuffs.