### PR TITLE
Set foreign key for subscriptions() relation

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -102,7 +102,7 @@ trait Billable
      */
     public function subscriptions()
     {
-        return $this->hasMany(Subscription::class)->orderBy('created_at', 'desc');
+        return $this->hasMany(Subscription::class, 'user_id')->orderBy('created_at', 'desc');
     }
 
     /**


### PR DESCRIPTION
Set the foreign key for the subscriptions() relation to "user_id". The user() relation in Subscription.php already sets the local key to "user_id", so this is just the other side of the relationship. This is necessary to handle cases where the Stripe model isn't "User".