### PR TITLE
Update package name to match packagist existing name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravel/new-cashier",
+    "name": "laravel/cashier",
     "description": "Laravel Cashier provides an expressive, fluent interface to Stripe's subscription billing services.",
     "keywords": ["laravel", "stripe", "billing"],
     "license": "MIT",


### PR DESCRIPTION
Currently the package.json name was changed to "new-cashier".  This doesn't match the packagist name.  From what I could find out, there's not a simple way to update the packagist name.
Because the names don't match up, it makes it not possible to fork the repo and override it in the "repositories" root object.