### PR TITLE
Change order of boolean test for faster tests

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -20,7 +20,7 @@ class WebhookController extends Controller
     {
         $payload = json_decode($request->getContent(), true);
 
-        if ( ! $this->isInTestingEnvironment() && ! $this->eventExistsOnStripe($payload['id'])) {
+        if (! $this->isInTestingEnvironment() && ! $this->eventExistsOnStripe($payload['id'])) {
             return;
         }
 

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -20,7 +20,7 @@ class WebhookController extends Controller
     {
         $payload = json_decode($request->getContent(), true);
 
-        if (! $this->eventExistsOnStripe($payload['id']) && ! $this->isInTestingEnvironment()) {
+        if ( ! $this->isInTestingEnvironment() && ! $this->eventExistsOnStripe($payload['id'])) {
             return;
         }
 


### PR DESCRIPTION
The logic of the Boolean expression in the previous order makes it so that the event existence is always checked against the Stripe servers first before checking whether this is a test. This results in slower tests as each test will make this round trip even though the condition will make it so the result is irrelevant.

The proposed ordering omits the check against the Stripe servers entirely during tests. This change has no real consequence in terms of effective logic since even if one explicitly wanted it to check that the event exists in Stripe, the `&& !` was making the result irrelevant when testing.

This is the propose PR for #261.