### PR TITLE
Add relation on a given model, rather than hard-coded relation

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -34,7 +34,7 @@ class Subscription extends Model
         $model = getenv('STRIPE_MODEL') ?: config('services.stripe.model');
         $relation = config('services.stripe.relation') ?: Str::snake(class_basename($model)).'_id';
 
-        return $this->belongsTo($model, 'user_id');
+        return $this->belongsTo($model, $relation);
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier;
 
 use Carbon\Carbon;
 use LogicException;
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 
 class Subscription extends Model
@@ -31,6 +32,7 @@ class Subscription extends Model
     public function user()
     {
         $model = getenv('STRIPE_MODEL') ?: config('services.stripe.model');
+        $relation = config('services.stripe.relation') ?: Str::snake(class_basename($model)).'_id';
 
         return $this->belongsTo($model, 'user_id');
     }


### PR DESCRIPTION
At the moment when you try to cancel a subscription on Cashier and are not using the standard User model, it fails since it is trying to look up the `user_id` relation in the DB when that may not exist. My fix allows Cashier to look up the relation from a config setting or guess based from the model.