### PR TITLE
Fix the foreign key for the different models

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -133,7 +133,7 @@ trait Billable
      */
     public function subscriptions()
     {
-        return $this->hasMany(Subscription::class)->orderBy('created_at', 'desc');
+        return $this->hasMany(Subscription::class, 'user_id')->orderBy('created_at', 'desc');
     }
 
     /**


### PR DESCRIPTION
If the developer uses the trait Billable in models with a name different from 'User', the foreign key is set incorrect, already what the pattern is 'user_id'.