### PR TITLE
Changed the Stripe env variable name

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -406,7 +406,7 @@ trait Billable
      */
     public static function getStripeKey()
     {
-        return static::$stripeKey ?: getenv('STRIPE_SECRET');
+        return static::$stripeKey ?: env('STRIPE_API_SECRET');
     }
 
     /**


### PR DESCRIPTION
There seems to be a discrepancy in the environment variables names written in the documentation and the one that is called in Billable `get_stripe_key()` method. The documentation says:

> Stripe Key
> 
> Finally, set your Stripe key in your services.php configuration file:
> 
> 'stripe' => [
>     'model'  => App\User::class,
>     'secret' => env('STRIPE_API_SECRET'),
> ],

And `get_stripe_key()` does:

```
return static::$stripeKey ?: getenv('STRIPE_SECRET');
```

I am somewhat new to cashier so there might be something I didn't get. Although, changing the env variable name fixed the error I was getting, which was exactly like this one #243.