### PR TITLE
Remove unnecessary else from formatAmount() method.

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -38,8 +38,8 @@ class Cashier
 
         if (starts_with($amount, '-')) {
             return '-$'.ltrim($amount, '-');
-        } else {
-            return '$'.$amount;
         }
+
+        return '$'.$amount;
     }
 }


### PR DESCRIPTION
Clean up formatAmount() method by removing unnecessary else statement.