### PR TITLE
Added no prorate and billing cycle anchor setters for subscription swapping.

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -196,7 +196,11 @@ class Subscription extends Model
 
         $subscription->prorate = $this->prorate;
 
-        $subscription->billing_cycle_anchor = $this->billing_cycle_anchor;
+        // If billing_cycle_anchor is set add it to payload.
+        if(!is_null($this->billing_cycle_anchor))
+        {
+            $subscription->billing_cycle_anchor = $this->billing_cycle_anchor;
+        }
 
         // If no specific trial end date has been set, the default behavior should be
         // to maintain the current trial state, whether that is "active" or to run

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -25,6 +25,20 @@ class Subscription extends Model
     ];
 
     /**
+     * Indicates if the plan change should be prorated.
+     *
+     * @var bool
+     */
+    protected $prorate = true;
+
+    /**
+     * Change the billing cycle anchor on plan change.
+     *
+     * @var string|null
+     */
+    protected $billing_cycle_anchor = null;
+
+    /**
      * Get the user that owns the subscription.
      */
     public function user()
@@ -144,6 +158,31 @@ class Subscription extends Model
     }
 
     /**
+     * Indicate that the plan change should be prorated.
+     *
+     * @return $this
+     */
+    public function noProrate()
+    {
+        $this->prorate = false;
+
+        return $this;
+    }
+
+    /**
+     * Change the billing cycle anchor on plan change.
+     *
+     * @param string $date
+     * @return $this
+     */
+    public function billingCycleAnchor($date = "now")
+    {
+        $this->billing_cycle_anchor = $date;
+
+        return $this;
+    }
+
+    /**
      * Swap the subscription to a new Stripe plan.
      *
      * @param  string  $plan
@@ -154,6 +193,10 @@ class Subscription extends Model
         $subscription = $this->asStripeSubscription();
 
         $subscription->plan = $plan;
+
+        $subscription->prorate = $this->prorate;
+
+        $subscription->billing_cycle_anchor = $this->billing_cycle_anchor;
 
         // If no specific trial end date has been set, the default behavior should be
         // to maintain the current trial state, whether that is "active" or to run


### PR DESCRIPTION
This is a little update that allows you to set prorate and billing_cycle_anchor when swapping a subscription plan.

Usage is:

`$user->subscription()->noProrate()->billingCycleAnchor("now")->swap($stripe_plan);`

I proposed this need way back in 2014 on this pull request: https://github.com/laravel/cashier/pull/88

It looks like it was implemented elsewhere: https://github.com/laravel/cashier/pull/210

But subsequently dropped in Cashier 6.0 (along with noProrate()) unless I'm massively overlooking something.