### PR TITLE
Added no prorate and billing cycle anchor setters for subscription swapping.

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -188,7 +188,7 @@ class Subscription extends Model
      * @param string $date
      * @return $this
      */
-    public function billingCycleAnchor($date = "now")
+    public function billingCycleAnchor($date = 'now')
     {
         $this->billing_cycle_anchor = $date;
 
@@ -210,8 +210,7 @@ class Subscription extends Model
         $subscription->prorate = $this->prorate;
 
         // If billing_cycle_anchor is set add it to payload.
-        if(!is_null($this->billing_cycle_anchor))
-        {
+        if (! is_null($this->billing_cycle_anchor)) {
             $subscription->billing_cycle_anchor = $this->billing_cycle_anchor;
         }
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -26,6 +26,20 @@ class Subscription extends Model
     ];
 
     /**
+     * Indicates if the plan change should be prorated.
+     *
+     * @var bool
+     */
+    protected $prorate = true;
+
+    /**
+     * Change the billing cycle anchor on plan change.
+     *
+     * @var string|null
+     */
+    protected $billing_cycle_anchor = null;
+
+    /**
      * Get the user that owns the subscription.
      */
     public function user()
@@ -157,6 +171,31 @@ class Subscription extends Model
     }
 
     /**
+     * Indicate that the plan change should be prorated.
+     *
+     * @return $this
+     */
+    public function noProrate()
+    {
+        $this->prorate = false;
+
+        return $this;
+    }
+
+    /**
+     * Change the billing cycle anchor on plan change.
+     *
+     * @param string $date
+     * @return $this
+     */
+    public function billingCycleAnchor($date = "now")
+    {
+        $this->billing_cycle_anchor = $date;
+
+        return $this;
+    }
+
+    /**
      * Swap the subscription to a new Stripe plan.
      *
      * @param  string  $plan
@@ -167,6 +206,14 @@ class Subscription extends Model
         $subscription = $this->asStripeSubscription();
 
         $subscription->plan = $plan;
+
+        $subscription->prorate = $this->prorate;
+
+        // If billing_cycle_anchor is set add it to payload.
+        if(!is_null($this->billing_cycle_anchor))
+        {
+            $subscription->billing_cycle_anchor = $this->billing_cycle_anchor;
+        }
 
         // If no specific trial end date has been set, the default behavior should be
         // to maintain the current trial state, whether that is "active" or to run

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -185,7 +185,9 @@ class Subscription extends Model
     /**
      * Change the billing cycle anchor on plan change.
      *
-     * @param string $date
+     * $date can be either a Unix timestamp or special value 'now'.
+     *
+     * @param int|string $date
      * @return $this
      */
     public function billingCycleAnchor($date = 'now')


### PR DESCRIPTION
**Moved this onto branch 6.0 as requested**

This is a little update that allows you to set prorate and billing_cycle_anchor when swapping a subscription plan.

Usage is:

$user->subscription()->noProrate()->billingCycleAnchor("now")->swap($stripe_plan);

I proposed this need way back in 2014 on this pull request: #88

It looks like it was implemented elsewhere: #210

But subsequently dropped in Cashier 6.0 (along with noProrate()) unless I'm massively overlooking something.