### PR TITLE
onPlan() issue with valid plans

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -385,7 +385,7 @@ trait Billable
     public function onPlan($plan)
     {
         return ! is_null($this->subscriptions->first(function ($key, $value) use ($plan) {
-            return $value->stripe_plan === $plan;
+            return $value->stripe_plan === $plan && $value->valid();
         }));
     }
 


### PR DESCRIPTION
Since a user can cancel a plan and re-subscribe, this method could return an invalid plan. This fix will only return valid ones (which I think is the desired behavior?).