### PR TITLE
Fix onGenericTrial() method error

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -123,7 +123,7 @@ trait Billable
      */
     public function onGenericTrial()
     {
-        return $this->trial_ends_at && Carbon::now()->lt($this->trial_ends_at);
+        return $this->trial_ends_at && Carbon::now()->lt(Carbon::instance(new \DateTime($this->trial_ends_at)));
     }
 
     /**


### PR DESCRIPTION
In order for the Carbon::now()->lt() method to work, it's supposed to have the Carbon instance as an argument:

```
    /**
     * Determines if the instance is less (before) than another
     *
     * @param Carbon $dt
     *
     * @return bool
     */
    public function lt(Carbon $dt)
    {
        return $this < $dt;
    }
```


