### PR TITLE
Replaced getenv('STRIPE_SECRET') calls with config('services.stripe.secret')

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -467,7 +467,7 @@ trait Billable
      */
     public static function getStripeKey()
     {
-        return static::$stripeKey ?: getenv('STRIPE_SECRET');
+        return static::$stripeKey ?: config('services.stripe.secret');
     }
 
     /**

--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -281,7 +281,7 @@ class CashierTest extends PHPUnit_Framework_TestCase
                 'exp_year' => 2020,
                 'cvc' => '123',
             ],
-        ], ['api_key' => getenv('STRIPE_SECRET')])->id;
+        ], ['api_key' => config('services.stripe.secret')])->id;
     }
 
     /**


### PR DESCRIPTION
Replaced getenv() call with config() - this way we aren't being forced to have the environment key named `STRIPE_SECRET`.