### PR TITLE
Pass coupon to Stripe API when using withCoupon

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -215,6 +215,7 @@ class SubscriptionBuilder
         return array_filter([
             'plan' => $this->plan,
             'quantity' => $this->quantity,
+            'coupon' => $this->coupon,
             'trial_end' => $this->getTrialEndForPayload(),
             'tax_percent' => $this->getTaxPercentageForPayload(),
             'metadata' => $this->metadata,


### PR DESCRIPTION
Coupon must be passed to the stripe API on subscription creation for the withCoupon method to do anything.

This is a pretty big oversight. I don't know if it's worth putting out an email or something. Customers of anyone using withCoupon on signup are not getting their coupons applied.