### PR TITLE
Add hasCardOnFile method to Billable

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -83,13 +83,20 @@ trait Billable
 
         $customer = $this->asStripeCustomer();
 
-        // If we determines that the customer has a card (desync?),
-        // we'll set it back onto the user model and save it.
-        if ($source = $customer->default_source) {
-            $this->fillCardDetails($source)->save();
+        $source = null;
+
+        foreach ($customer->sources->data as $card) {
+            if ($card->id === $customer->default_source) {
+                $source = $card;
+                continue;
+            }
         }
 
-        return (bool) $source;
+        // If we determines that the customer has a card (desync?),
+        // we'll set it back onto the user model and save it.
+        $this->fillCardDetails($source)->save();
+
+        return (bool)$source;
     }
 
     /**

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -89,7 +89,7 @@ trait Billable
             $this->fillCardDetails($source)->save();
         }
 
-        return (bool)$source;
+        return (bool) $source;
     }
 
     /**
@@ -104,6 +104,7 @@ trait Billable
             $this->card_brand = $source->brand;
             $this->card_last_four = $source->last4;
         }
+
         return $this;
     }
 

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -96,7 +96,7 @@ trait Billable
         // we'll set it back onto the user model and save it.
         $this->fillCardDetails($source)->save();
 
-        return (bool)$source;
+        return (bool) $source;
     }
 
     /**

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -385,10 +385,7 @@ trait Billable
                     ? $customer->sources->retrieve($customer->default_source)
                     : null;
 
-        if ($source) {
-            $this->card_brand = $source->brand;
-            $this->card_last_four = $source->last4;
-        }
+        $this->fillCardDetails($source);
 
         $this->save();
     }

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -83,7 +83,8 @@ trait Billable
      *
      * @return $this
      */
-    public function syncCustomerCardDetails() {
+    public function syncCustomerCardDetails()
+    {
         $customer = $this->asStripeCustomer();
 
         // Let's go through all the users' sources (cards) until we find


### PR DESCRIPTION
Allows you to check if the customer currently has a card on file.

This PR adds three methods:
* `public function hasCardOnFile() : bool` **Determines if the user, according to the local DB, has a card linked.**
* `public function syncCustomerCardDetails : $this` **Forces the refresh of the customer's card details from Stripe's API.**
* `protected function fillCardDetails : $this` **Replaces the data about the card in the database for the Billable model.**