### PR TITLE
Dates improved

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -137,7 +137,10 @@
                     @foreach ($invoice->subscriptions() as $subscription)
                         <tr>
                             <td>Subscription ({{ $subscription->quantity }})</td>
-                            <td>{{ $subscription->startDate() }} - {{ $subscription->endDate() }}</td>
+                            <td>
+                                {{ $subscription->startDateAsCarbon()->formatLocalized('%B %e, %Y') }} -
+                                {{ $subscription->endDateAsCarbon()->formatLocalized('%B %e, %Y') }}
+                            </td>
                             <td>{{ $subscription->total() }}</td>
                         </tr>
                     @endforeach

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -45,7 +45,7 @@ class Invoice
      */
     public function date($timezone = null)
     {
-        $carbon = Carbon::createFromTimestamp($this->invoice->date);
+        $carbon = Carbon::createFromTimestampUTC($this->invoice->date);
 
         return $timezone ? $carbon->setTimezone($timezone) : $carbon;
     }

--- a/src/InvoiceItem.php
+++ b/src/InvoiceItem.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Cashier;
 
+use Carbon\Carbon;
+
 class InvoiceItem
 {
     /**
@@ -62,6 +64,30 @@ class InvoiceItem
     {
         if ($this->isSubscription()) {
             return date('M j, Y', $this->item->period->end);
+        }
+    }
+
+    /**
+     * Get a Carbon instance for the start date.
+     *
+     * @return \Carbon\Carbon
+     */
+    public function startDateAsCarbon()
+    {
+        if ($this->isSubscription()) {
+            return Carbon::createFromTimestampUTC($this->item->period->start);
+        }
+    }
+
+    /**
+     * Get a Carbon instance for the end date.
+     *
+     * @return \Carbon\Carbon
+     */
+    public function endDateAsCarbon()
+    {
+        if ($this->isSubscription()) {
+            return Carbon::createFromTimestampUTC($this->item->period->end);
         }
     }
 

--- a/src/InvoiceItem.php
+++ b/src/InvoiceItem.php
@@ -51,7 +51,7 @@ class InvoiceItem
     public function startDate()
     {
         if ($this->isSubscription()) {
-            return date('M j, Y', $this->item->period->start);
+            return $this->startDateAsCarbon()->toFormattedDateString();
         }
     }
 
@@ -63,7 +63,7 @@ class InvoiceItem
     public function endDate()
     {
         if ($this->isSubscription()) {
-            return date('M j, Y', $this->item->period->end);
+            return $this->endDateAsCarbon()->toFormattedDateString();
         }
     }
 


### PR DESCRIPTION
Invoice items now use Carbon for start and end dates in subscriptions (allows formatting and localization)
Invoice date now uses UTC for instantiation since Stripe's API uses UTC for all dates (see https://support.stripe.com/questions/what-timezone-does-the-dashboard-and-api-use)