### PR TITLE
Use Stripe's trial_end

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -168,7 +168,8 @@ class SubscriptionBuilder
         if ($this->skipTrial) {
             $trialEndsAt = null;
         } else {
-            $trialEndsAt = $this->trialDays ? Carbon::now()->addDays($this->trialDays) : null;
+            $trialEndsAt = $subscription->trial_end ? Carbon::createFromTimestampUTC($subscription->trial_end)
+                ->toDateTimeString() : null;
         }
 
         return $this->user->subscriptions()->create([


### PR DESCRIPTION
Make sure we get the right trial_ends_at data from Stripe itself. Stripe plans can have default trial periods, which will fix this issue. ->trialDays() will also still work since we get the end date from the subscription itself.

Fixes #256