### PR TITLE
Use the config value when retrieving the Stripe key

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -538,7 +538,7 @@ trait Billable
      */
     public static function getStripeKey()
     {
-        return static::$stripeKey ?: getenv('STRIPE_SECRET');
+        return static::$stripeKey ?: config('services.stripe.secret');
     }
 
     /**


### PR DESCRIPTION
In the Cashier documentation, it's mention that a requirement for getting setup for Stripe is to set the model and secret values in services.php. 

Currently when retrieving the Stripe key, Cashier is defaulting to using the getenv() function to retrieve the key instead of the config() function. 

When using the Laravel config cache option:
`php artisan config:cache`
Cashier stops working as the getStripeKey() function returns `false`.

This patch simply uses the config() function in place of the getenv() function, and fixes Cashier for everyone caching their config via Laravel. The solution was mentioned in #243 