### PR TITLE
Allow subscription relation to be specified in config

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -46,8 +46,9 @@ class Subscription extends Model
     public function user()
     {
         $model = getenv('STRIPE_MODEL') ?: config('services.stripe.model', 'User');
+        $modelId = getenv('STRIPE_MODEL_ID') ?: config('services.stripe.modelId', 'user_id');
 
-        return $this->belongsTo($model, 'user_id');
+        return $this->belongsTo($model, $modelId);
     }
 
     /**


### PR DESCRIPTION
I'm using Cashier on a different model than User so when following the [docs](https://laravel.com/docs/5.2/billing#stripe-configuration) adding the migration for the `subscriptions` table I'm using a different column than `user_id`.

This PR allows the relation to be defined in config, but defaults to `user_id` so should be backwards compatible.

It's not optimal as ideally it would be great to change `Subscription::user()` to something more appropriate but this fix allows subscriptions to be created, swapped and cancelled with the existing codebase.