### PR TITLE
#320 fixed with backward compatibility to laravel 5.2

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -188,6 +188,11 @@ trait Billable
             return $value->created_at->getTimestamp();
         })
         ->first(function ($key, $value) use ($subscription) {
+            // here we will inspect if the $key is Subscription (this will true for laravel 5.3)
+            if($key instanceof Subscription) {
+                return $key->name === $subscription;
+            }
+            // if laravel 5.2 then $value will be Subscription object
             return $value->name === $subscription;
         });
     }

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -189,7 +189,7 @@ trait Billable
         })
         ->first(function ($key, $value) use ($subscription) {
             // here we will inspect if the $key is Subscription (this will true for laravel 5.3)
-            if($key instanceof Subscription) {
+            if ($key instanceof Subscription) {
                 return $key->name === $subscription;
             }
             // if laravel 5.2 then $value will be Subscription object


### PR DESCRIPTION
I have added a simple if to check the parameter order if its laravel 5.3 then first param will instance of Subscription otherwise second param will be instance of Subscription.