### PR TITLE
removed extra else

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -28,9 +28,9 @@ class WebhookController extends Controller
 
         if (method_exists($this, $method)) {
             return $this->{$method}($payload);
-        } else {
-            return $this->missingMethod();
         }
+
+        return $this->missingMethod();
     }
 
     /**


### PR DESCRIPTION
Removed extra else after if, no else statement is required if (if) statement is not true, simply we can do:

` ``
       if (method_exists($this, $method)) {
            return $this->{$method}($payload);
        }
        
        return $this->missingMethod();
```