### PR TITLE
[Proposal] Upgrade to Dompdf v0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.5.9",
         "illuminate/database": "~5.3",
         "illuminate/support": "~5.3",
-        "dompdf/dompdf": "^0.6.1",
+        "dompdf/dompdf": "^0.7.0",
         "nesbot/carbon": "~1.0",
         "stripe/stripe-php": "~3.0",
         "symfony/http-kernel": "~2.7|~3.0"

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Cashier;
 
-use DOMPDF;
 use Carbon\Carbon;
+use Dompdf\Dompdf;
 use Illuminate\Support\Facades\View;
 use Stripe\Invoice as StripeInvoice;
 use Symfony\Component\HttpFoundation\Response;
@@ -254,9 +254,9 @@ class Invoice
             require_once $configPath;
         }
 
-        $dompdf = new DOMPDF;
+        $dompdf = new Dompdf;
 
-        $dompdf->load_html($this->view($data)->render());
+        $dompdf->loadHtml($this->view($data)->render());
 
         $dompdf->render();
 


### PR DESCRIPTION
Currently Cashier requires `dompdf/dompdf@^0.6.1`. The `dompdf` package has been updated to `0.7` so this now shows as an outdated package when running `composer outdated -D` on a Laravel 5.3 project.

I have updated Cashier to use Dompdf 0.7 and tested the PDF downloads using our Laravel 5.3 application. I have also run PHPUnit on this change which resulted in 0 failures.

```
$ ./vendor/bin/phpunit
PHPUnit 4.8.27 by Sebastian Bergmann and contributors.

..........

Time: 40.91 seconds, Memory: 8.00MB

OK (10 tests, 58 assertions)
```