### PR TITLE
Enabled dynamic loading of Stripe model

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,9 @@ You will need to set the following details locally and on your Stripe account in
 
 #### .env
 
-    STRIPE_API_KEY=
+    STRIPE_KEY=
     STRIPE_SECRET=
+    STRIPE_MODEL=User
 
 ### Stripe
 

--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -72,7 +72,7 @@
             <!-- Organization Name / Date -->
             <td>
                 <br><br>
-                <strong>To:</strong> {{ $user->email ?: $user->name }}
+                <strong>To:</strong> {{ $owner->email ?: $owner->name }}
                 <br>
                 <strong>Date:</strong> {{ $invoice->date()->toFormattedDateString() }}
             </td>

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -17,546 +17,546 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 trait Billable
 {
-    /**
-     * The Stripe API key.
-     *
-     * @var string
-     */
-    protected static $stripeKey;
-
-    /**
-     * Make a "one off" charge on the customer for the given amount.
-     *
-     * @param  int  $amount
-     * @param  array  $options
-     * @return \Stripe\Charge
-     *
-     * @throws \Stripe\Error\Card
-     */
-    public function charge($amount, array $options = [])
-    {
-        $options = array_merge([
-            'currency' => $this->preferredCurrency(),
-        ], $options);
-
-        $options['amount'] = $amount;
-
-        if (! array_key_exists('source', $options) && $this->stripe_id) {
-            $options['customer'] = $this->stripe_id;
-        }
-
-        if (! array_key_exists('source', $options) && ! array_key_exists('customer', $options)) {
-            throw new InvalidArgumentException('No payment source provided.');
-        }
-
-        return StripeCharge::create($options, ['api_key' => $this->getStripeKey()]);
-    }
-
-    /**
-     * Refund a customer for a charge.
-     *
-     * @param  string  $charge
-     * @param  array  $options
-     * @return \Stripe\Charge
-     *
-     * @throws \Stripe\Error\Refund
-     */
-    public function refund($charge, array $options = [])
-    {
-        $options['charge'] = $charge;
-
-        return StripeRefund::create($options, ['api_key' => $this->getStripeKey()]);
-    }
-
-    /**
-     * Determines if the customer currently has a card on file.
-     *
-     * @return bool
-     */
-    public function hasCardOnFile()
-    {
-        return (bool) $this->card_brand;
-    }
-
-    /**
-     * Invoice the customer for the given amount.
-     *
-     * @param  string  $description
-     * @param  int  $amount
-     * @param  array  $options
-     * @return bool
-     *
-     * @throws \Stripe\Error\Card
-     */
-    public function invoiceFor($description, $amount, array $options = [])
-    {
-        if (! $this->stripe_id) {
-            throw new InvalidArgumentException(class_basename($this).' is not a Stripe customer. See the createAsStripeCustomer method.');
-        }
-
-        $options = array_merge([
-            'customer' => $this->stripe_id,
-            'amount' => $amount,
-            'currency' => $this->preferredCurrency(),
-            'description' => $description,
-        ], $options);
-
-        StripeInvoiceItem::create(
-            $options, ['api_key' => $this->getStripeKey()]
-        );
-
-        return $this->invoice();
-    }
-
-    /**
-     * Begin creating a new subscription.
-     *
-     * @param  string  $subscription
-     * @param  string  $plan
-     * @return \Laravel\Cashier\SubscriptionBuilder
-     */
-    public function newSubscription($subscription, $plan)
-    {
-        return new SubscriptionBuilder($this, $subscription, $plan);
-    }
-
-    /**
-     * Determine if the Stripe model is on trial.
-     *
-     * @param  string  $subscription
-     * @param  string|null  $plan
-     * @return bool
-     */
-    public function onTrial($subscription = 'default', $plan = null)
-    {
-        if (func_num_args() === 0 && $this->onGenericTrial()) {
-            return true;
-        }
-
-        $subscription = $this->subscription($subscription);
-
-        if (is_null($plan)) {
-            return $subscription && $subscription->onTrial();
-        }
-
-        return $subscription && $subscription->onTrial() &&
-               $subscription->stripe_plan === $plan;
-    }
-
-    /**
-     * Determine if the Stripe model is on a "generic" trial at the model level.
-     *
-     * @return bool
-     */
-    public function onGenericTrial()
-    {
-        return $this->trial_ends_at && Carbon::now()->lt($this->trial_ends_at);
-    }
-
-    /**
-     * Determine if the Stripe model has a given subscription.
-     *
-     * @param  string  $subscription
-     * @param  string|null  $plan
-     * @return bool
-     */
-    public function subscribed($subscription = 'default', $plan = null)
-    {
-        $subscription = $this->subscription($subscription);
-
-        if (is_null($subscription)) {
-            return false;
-        }
-
-        if (is_null($plan)) {
-            return $subscription->valid();
-        }
-
-        return $subscription->valid() &&
-               $subscription->stripe_plan === $plan;
-    }
-
-    /**
-     * Get a subscription instance by name.
-     *
-     * @param  string  $subscription
-     * @return \Laravel\Cashier\Subscription|null
-     */
-    public function subscription($subscription = 'default')
-    {
-        return $this->subscriptions->sortByDesc(function ($value) {
-            return $value->created_at->getTimestamp();
-        })
-        ->first(function ($value) use ($subscription) {
-            return $value->name === $subscription;
-        });
-    }
-
-    /**
-     * Get all of the subscriptions for the Stripe model.
-     *
-     * @return \Illuminate\Database\Eloquent\Collection
-     */
-    public function subscriptions()
-    {
-        return $this->hasMany(Subscription::class, $this->getForeignKey())->orderBy('created_at', 'desc');
-    }
-
-    /**
-     * Invoice the billable entity outside of regular billing cycle.
-     *
-     * @return StripeInvoice|bool
-     */
-    public function invoice()
-    {
-        if ($this->stripe_id) {
-            try {
-                return StripeInvoice::create(['customer' => $this->stripe_id], $this->getStripeKey())->pay();
-            } catch (StripeErrorInvalidRequest $e) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Get the entity's upcoming invoice.
-     *
-     * @return \Laravel\Cashier\Invoice|null
-     */
-    public function upcomingInvoice()
-    {
-        try {
-            $stripeInvoice = StripeInvoice::upcoming(
-                ['customer' => $this->stripe_id], ['api_key' => $this->getStripeKey()]
-            );
-
-            return new Invoice($this, $stripeInvoice);
-        } catch (StripeErrorInvalidRequest $e) {
-            //
-        }
-    }
-
-    /**
-     * Find an invoice by ID.
-     *
-     * @param  string  $id
-     * @return \Laravel\Cashier\Invoice|null
-     */
-    public function findInvoice($id)
-    {
-        try {
-            return new Invoice($this, StripeInvoice::retrieve($id, $this->getStripeKey()));
-        } catch (Exception $e) {
-            //
-        }
-    }
-
-    /**
-     * Find an invoice or throw a 404 error.
-     *
-     * @param  string  $id
-     * @return \Laravel\Cashier\Invoice
-     */
-    public function findInvoiceOrFail($id)
-    {
-        $invoice = $this->findInvoice($id);
-
-        if (is_null($invoice)) {
-            throw new NotFoundHttpException;
-        }
-
-        return $invoice;
-    }
-
-    /**
-     * Create an invoice download Response.
-     *
-     * @param  string  $id
-     * @param  array   $data
-     * @param  string  $storagePath
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    public function downloadInvoice($id, array $data, $storagePath = null)
-    {
-        return $this->findInvoiceOrFail($id)->download($data, $storagePath);
-    }
-
-    /**
-     * Get a collection of the entity's invoices.
-     *
-     * @param  bool  $includePending
-     * @param  array  $parameters
-     * @return \Illuminate\Support\Collection
-     */
-    public function invoices($includePending = false, $parameters = [])
-    {
-        $invoices = [];
-
-        $parameters = array_merge(['limit' => 24], $parameters);
-
-        $stripeInvoices = $this->asStripeCustomer()->invoices($parameters);
-
-        // Here we will loop through the Stripe invoices and create our own custom Invoice
-        // instances that have more helper methods and are generally more convenient to
-        // work with than the plain Stripe objects are. Then, we'll return the array.
-        if (! is_null($stripeInvoices)) {
-            foreach ($stripeInvoices->data as $invoice) {
-                if ($invoice->paid || $includePending) {
-                    $invoices[] = new Invoice($this, $invoice);
-                }
-            }
-        }
-
-        return new Collection($invoices);
-    }
-
-    /**
-     * Get an array of the entity's invoices.
-     *
-     * @param  array  $parameters
-     * @return \Illuminate\Support\Collection
-     */
-    public function invoicesIncludingPending(array $parameters = [])
-    {
-        return $this->invoices(true, $parameters);
-    }
-
-    /**
-     * Update customer's credit card.
-     *
-     * @param  string  $token
-     * @return void
-     */
-    public function updateCard($token)
-    {
-        $customer = $this->asStripeCustomer();
-
-        $token = StripeToken::retrieve($token, ['api_key' => $this->getStripeKey()]);
-
-        // If the given token already has the card as their default source, we can just
-        // bail out of the method now. We don't need to keep adding the same card to
-        // the model's account each time we go through this particular method call.
-        if ($token->card->id === $customer->default_source) {
-            return;
-        }
-
-        $card = $customer->sources->create(['source' => $token]);
-
-        $customer->default_source = $card->id;
-
-        $customer->save();
-
-        // Next, we will get the default source for this model so we can update the last
-        // four digits and the card brand on this model's record in the database, which
-        // is convenient when displaying on the front-end when updating the cards.
-        $source = $customer->default_source
-                    ? $customer->sources->retrieve($customer->default_source)
-                    : null;
-
-        $this->fillCardDetails($source);
-
-        $this->save();
-    }
-
-    /**
-     * Synchronises the customer's card from Stripe back into the database.
-     *
-     * @return $this
-     */
-    public function updateCardFromStripe()
-    {
-        $customer = $this->asStripeCustomer();
-
-        $defaultCard = null;
-
-        foreach ($customer->sources->data as $card) {
-            if ($card->id === $customer->default_source) {
-                $defaultCard = $card;
-                break;
-            }
-        }
-
-        if ($defaultCard) {
-            $this->fillCardDetails($defaultCard)->save();
-        } else {
-            $this->forceFill([
-                'card_brand' => null,
-                'card_last_four' => null,
-            ])->save();
-        }
-
-        return $this;
-    }
-
-    /**
-     * Fills the model's properties with the source from Stripe.
-     *
-     * @param \Stripe\Card|null  $card
-     * @return $this
-     */
-    protected function fillCardDetails($card)
-    {
-        if ($card) {
-            $this->card_brand = $card->brand;
-            $this->card_last_four = $card->last4;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Apply a coupon to the billable entity.
-     *
-     * @param  string  $coupon
-     * @return void
-     */
-    public function applyCoupon($coupon)
-    {
-        $customer = $this->asStripeCustomer();
-
-        $customer->coupon = $coupon;
-
-        $customer->save();
-    }
-
-    /**
-     * Determine if the Stripe model is actively subscribed to one of the given plans.
-     *
-     * @param  array|string  $plans
-     * @param  string  $subscription
-     * @return bool
-     */
-    public function subscribedToPlan($plans, $subscription = 'default')
-    {
-        $subscription = $this->subscription($subscription);
-
-        if (! $subscription || ! $subscription->valid()) {
-            return false;
-        }
-
-        foreach ((array) $plans as $plan) {
-            if ($subscription->stripe_plan === $plan) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Determine if the entity is on the given plan.
-     *
-     * @param  string  $plan
-     * @return bool
-     */
-    public function onPlan($plan)
-    {
-        return ! is_null($this->subscriptions->first(function ($value) use ($plan) {
-            return $value->stripe_plan === $plan && $value->valid();
-        }));
-    }
-
-    /**
-     * Determine if the entity has a Stripe customer ID.
-     *
-     * @return bool
-     */
-    public function hasStripeId()
-    {
-        return ! is_null($this->stripe_id);
-    }
-
-    /**
-     * Create a Stripe customer for the given Stripe model.
-     *
-     * @param  string  $token
-     * @param  array  $options
-     * @return StripeCustomer
-     */
-    public function createAsStripeCustomer($token, array $options = [])
-    {
-        $options = array_key_exists('email', $options)
-                ? $options : array_merge($options, ['email' => $this->email]);
-
-        // Here we will create the customer instance on Stripe and store the ID of the
-        // user from Stripe. This ID will correspond with the Stripe user instances
-        // and allow us to retrieve users from Stripe later when we need to work.
-        $customer = StripeCustomer::create(
-            $options, $this->getStripeKey()
-        );
-
-        $this->stripe_id = $customer->id;
-
-        $this->save();
-
-        // Next we will add the credit card to the user's account on Stripe using this
-        // token that was provided to this method. This will allow us to bill users
-        // when they subscribe to plans or we need to do one-off charges on them.
-        if (! is_null($token)) {
-            $this->updateCard($token);
-        }
-
-        return $customer;
-    }
-
-    /**
-     * Get the Stripe customer for the Stripe model.
-     *
-     * @return \Stripe\Customer
-     */
-        public function asStripeCustomer()
-    {
-        return StripeCustomer::retrieve($this->stripe_id, $this->getStripeKey());
-    }
-
-    /**
-     * Get the Stripe supported currency used by the entity.
-     *
-     * @return string
-     */
-    public function preferredCurrency()
-    {
-        return Cashier::usesCurrency();
-    }
-
-    /**
-     * Get the tax percentage to apply to the subscription.
-     *
-     * @return int
-     */
-    public function taxPercentage()
-    {
-        return 0;
-    }
-
-    /**
-     * Get the Stripe API key.
-     *
-     * @return string
-     */
-    public static function getStripeKey()
-    {
-        if (static::$stripeKey) {
-            return static::$stripeKey;
-        }
-
-        if ($key = getenv('STRIPE_SECRET')) {
-            return $key;
-        }
-
-        return config('services.stripe.secret');
-    }
-
-    /**
-     * Set the Stripe API key.
-     *
-     * @param  string  $key
-     * @return void
-     */
-    public static function setStripeKey($key)
-    {
-        static::$stripeKey = $key;
-    }
+	/**
+	 * The Stripe API key.
+	 *
+	 * @var string
+	 */
+	protected static $stripeKey;
+
+	/**
+	 * Make a "one off" charge on the customer for the given amount.
+	 *
+	 * @param  int $amount
+	 * @param  array $options
+	 * @return \Stripe\Charge
+	 *
+	 * @throws \Stripe\Error\Card
+	 */
+	public function charge($amount, array $options = [])
+	{
+		$options = array_merge([
+			'currency' => $this->preferredCurrency(),
+		], $options);
+
+		$options['amount'] = $amount;
+
+		if (!array_key_exists('source', $options) && $this->stripe_id) {
+			$options['customer'] = $this->stripe_id;
+		}
+
+		if (!array_key_exists('source', $options) && !array_key_exists('customer', $options)) {
+			throw new InvalidArgumentException('No payment source provided.');
+		}
+
+		return StripeCharge::create($options, ['api_key' => $this->getStripeKey()]);
+	}
+
+	/**
+	 * Refund a customer for a charge.
+	 *
+	 * @param  string $charge
+	 * @param  array $options
+	 * @return \Stripe\Charge
+	 *
+	 * @throws \Stripe\Error\Refund
+	 */
+	public function refund($charge, array $options = [])
+	{
+		$options['charge'] = $charge;
+
+		return StripeRefund::create($options, ['api_key' => $this->getStripeKey()]);
+	}
+
+	/**
+	 * Determines if the customer currently has a card on file.
+	 *
+	 * @return bool
+	 */
+	public function hasCardOnFile()
+	{
+		return (bool)$this->card_brand;
+	}
+
+	/**
+	 * Invoice the customer for the given amount.
+	 *
+	 * @param  string $description
+	 * @param  int $amount
+	 * @param  array $options
+	 * @return bool
+	 *
+	 * @throws \Stripe\Error\Card
+	 */
+	public function invoiceFor($description, $amount, array $options = [])
+	{
+		if (!$this->stripe_id) {
+			throw new InvalidArgumentException(class_basename($this) . ' is not a Stripe customer. See the createAsStripeCustomer method.');
+		}
+
+		$options = array_merge([
+			'customer' => $this->stripe_id,
+			'amount' => $amount,
+			'currency' => $this->preferredCurrency(),
+			'description' => $description,
+		], $options);
+
+		StripeInvoiceItem::create(
+			$options, ['api_key' => $this->getStripeKey()]
+		);
+
+		return $this->invoice();
+	}
+
+	/**
+	 * Begin creating a new subscription.
+	 *
+	 * @param  string $subscription
+	 * @param  string $plan
+	 * @return \Laravel\Cashier\SubscriptionBuilder
+	 */
+	public function newSubscription($subscription, $plan)
+	{
+		return new SubscriptionBuilder($this, $subscription, $plan);
+	}
+
+	/**
+	 * Determine if the Stripe model is on trial.
+	 *
+	 * @param  string $subscription
+	 * @param  string|null $plan
+	 * @return bool
+	 */
+	public function onTrial($subscription = 'default', $plan = null)
+	{
+		if (func_num_args() === 0 && $this->onGenericTrial()) {
+			return true;
+		}
+
+		$subscription = $this->subscription($subscription);
+
+		if (is_null($plan)) {
+			return $subscription && $subscription->onTrial();
+		}
+
+		return $subscription && $subscription->onTrial() &&
+		$subscription->stripe_plan === $plan;
+	}
+
+	/**
+	 * Determine if the Stripe model is on a "generic" trial at the model level.
+	 *
+	 * @return bool
+	 */
+	public function onGenericTrial()
+	{
+		return $this->trial_ends_at && Carbon::now()->lt($this->trial_ends_at);
+	}
+
+	/**
+	 * Determine if the Stripe model has a given subscription.
+	 *
+	 * @param  string $subscription
+	 * @param  string|null $plan
+	 * @return bool
+	 */
+	public function subscribed($subscription = 'default', $plan = null)
+	{
+		$subscription = $this->subscription($subscription);
+
+		if (is_null($subscription)) {
+			return false;
+		}
+
+		if (is_null($plan)) {
+			return $subscription->valid();
+		}
+
+		return $subscription->valid() &&
+		$subscription->stripe_plan === $plan;
+	}
+
+	/**
+	 * Get a subscription instance by name.
+	 *
+	 * @param  string $subscription
+	 * @return \Laravel\Cashier\Subscription|null
+	 */
+	public function subscription($subscription = 'default')
+	{
+		return $this->subscriptions->sortByDesc(function ($value) {
+			return $value->created_at->getTimestamp();
+		})
+			->first(function ($value) use ($subscription) {
+				return $value->name === $subscription;
+			});
+	}
+
+	/**
+	 * Get all of the subscriptions for the Stripe model.
+	 *
+	 * @return \Illuminate\Database\Eloquent\Collection
+	 */
+	public function subscriptions()
+	{
+		return $this->hasMany(Subscription::class, $this->getForeignKey())->orderBy('created_at', 'desc');
+	}
+
+	/**
+	 * Invoice the billable entity outside of regular billing cycle.
+	 *
+	 * @return StripeInvoice|bool
+	 */
+	public function invoice()
+	{
+		if ($this->stripe_id) {
+			try {
+				return StripeInvoice::create(['customer' => $this->stripe_id], $this->getStripeKey())->pay();
+			} catch (StripeErrorInvalidRequest $e) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the entity's upcoming invoice.
+	 *
+	 * @return \Laravel\Cashier\Invoice|null
+	 */
+	public function upcomingInvoice()
+	{
+		try {
+			$stripeInvoice = StripeInvoice::upcoming(
+				['customer' => $this->stripe_id], ['api_key' => $this->getStripeKey()]
+			);
+
+			return new Invoice($this, $stripeInvoice);
+		} catch (StripeErrorInvalidRequest $e) {
+			//
+		}
+	}
+
+	/**
+	 * Find an invoice by ID.
+	 *
+	 * @param  string $id
+	 * @return \Laravel\Cashier\Invoice|null
+	 */
+	public function findInvoice($id)
+	{
+		try {
+			return new Invoice($this, StripeInvoice::retrieve($id, $this->getStripeKey()));
+		} catch (Exception $e) {
+			//
+		}
+	}
+
+	/**
+	 * Find an invoice or throw a 404 error.
+	 *
+	 * @param  string $id
+	 * @return \Laravel\Cashier\Invoice
+	 */
+	public function findInvoiceOrFail($id)
+	{
+		$invoice = $this->findInvoice($id);
+
+		if (is_null($invoice)) {
+			throw new NotFoundHttpException;
+		}
+
+		return $invoice;
+	}
+
+	/**
+	 * Create an invoice download Response.
+	 *
+	 * @param  string $id
+	 * @param  array $data
+	 * @param  string $storagePath
+	 * @return \Symfony\Component\HttpFoundation\Response
+	 */
+	public function downloadInvoice($id, array $data, $storagePath = null)
+	{
+		return $this->findInvoiceOrFail($id)->download($data, $storagePath);
+	}
+
+	/**
+	 * Get a collection of the entity's invoices.
+	 *
+	 * @param  bool $includePending
+	 * @param  array $parameters
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function invoices($includePending = false, $parameters = [])
+	{
+		$invoices = [];
+
+		$parameters = array_merge(['limit' => 24], $parameters);
+
+		$stripeInvoices = $this->asStripeCustomer()->invoices($parameters);
+
+		// Here we will loop through the Stripe invoices and create our own custom Invoice
+		// instances that have more helper methods and are generally more convenient to
+		// work with than the plain Stripe objects are. Then, we'll return the array.
+		if (!is_null($stripeInvoices)) {
+			foreach ($stripeInvoices->data as $invoice) {
+				if ($invoice->paid || $includePending) {
+					$invoices[] = new Invoice($this, $invoice);
+				}
+			}
+		}
+
+		return new Collection($invoices);
+	}
+
+	/**
+	 * Get an array of the entity's invoices.
+	 *
+	 * @param  array $parameters
+	 * @return \Illuminate\Support\Collection
+	 */
+	public function invoicesIncludingPending(array $parameters = [])
+	{
+		return $this->invoices(true, $parameters);
+	}
+
+	/**
+	 * Update customer's credit card.
+	 *
+	 * @param  string $token
+	 * @return void
+	 */
+	public function updateCard($token)
+	{
+		$customer = $this->asStripeCustomer();
+
+		$token = StripeToken::retrieve($token, ['api_key' => $this->getStripeKey()]);
+
+		// If the given token already has the card as their default source, we can just
+		// bail out of the method now. We don't need to keep adding the same card to
+		// the model's account each time we go through this particular method call.
+		if ($token->card->id === $customer->default_source) {
+			return;
+		}
+
+		$card = $customer->sources->create(['source' => $token]);
+
+		$customer->default_source = $card->id;
+
+		$customer->save();
+
+		// Next, we will get the default source for this model so we can update the last
+		// four digits and the card brand on this model's record in the database, which
+		// is convenient when displaying on the front-end when updating the cards.
+		$source = $customer->default_source
+			? $customer->sources->retrieve($customer->default_source)
+			: null;
+
+		$this->fillCardDetails($source);
+
+		$this->save();
+	}
+
+	/**
+	 * Synchronises the customer's card from Stripe back into the database.
+	 *
+	 * @return $this
+	 */
+	public function updateCardFromStripe()
+	{
+		$customer = $this->asStripeCustomer();
+
+		$defaultCard = null;
+
+		foreach ($customer->sources->data as $card) {
+			if ($card->id === $customer->default_source) {
+				$defaultCard = $card;
+				break;
+			}
+		}
+
+		if ($defaultCard) {
+			$this->fillCardDetails($defaultCard)->save();
+		} else {
+			$this->forceFill([
+				'card_brand' => null,
+				'card_last_four' => null,
+			])->save();
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Fills the model's properties with the source from Stripe.
+	 *
+	 * @param \Stripe\Card|null $card
+	 * @return $this
+	 */
+	protected function fillCardDetails($card)
+	{
+		if ($card) {
+			$this->card_brand = $card->brand;
+			$this->card_last_four = $card->last4;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Apply a coupon to the billable entity.
+	 *
+	 * @param  string $coupon
+	 * @return void
+	 */
+	public function applyCoupon($coupon)
+	{
+		$customer = $this->asStripeCustomer();
+
+		$customer->coupon = $coupon;
+
+		$customer->save();
+	}
+
+	/**
+	 * Determine if the Stripe model is actively subscribed to one of the given plans.
+	 *
+	 * @param  array|string $plans
+	 * @param  string $subscription
+	 * @return bool
+	 */
+	public function subscribedToPlan($plans, $subscription = 'default')
+	{
+		$subscription = $this->subscription($subscription);
+
+		if (!$subscription || !$subscription->valid()) {
+			return false;
+		}
+
+		foreach ((array)$plans as $plan) {
+			if ($subscription->stripe_plan === $plan) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine if the entity is on the given plan.
+	 *
+	 * @param  string $plan
+	 * @return bool
+	 */
+	public function onPlan($plan)
+	{
+		return !is_null($this->subscriptions->first(function ($value) use ($plan) {
+			return $value->stripe_plan === $plan && $value->valid();
+		}));
+	}
+
+	/**
+	 * Determine if the entity has a Stripe customer ID.
+	 *
+	 * @return bool
+	 */
+	public function hasStripeId()
+	{
+		return !is_null($this->stripe_id);
+	}
+
+	/**
+	 * Create a Stripe customer for the given Stripe model.
+	 *
+	 * @param  string $token
+	 * @param  array $options
+	 * @return StripeCustomer
+	 */
+	public function createAsStripeCustomer($token, array $options = [])
+	{
+		$options = array_key_exists('email', $options)
+			? $options : array_merge($options, ['email' => $this->email]);
+
+		// Here we will create the customer instance on Stripe and store the ID of the
+		// user from Stripe. This ID will correspond with the Stripe user instances
+		// and allow us to retrieve users from Stripe later when we need to work.
+		$customer = StripeCustomer::create(
+			$options, $this->getStripeKey()
+		);
+
+		$this->stripe_id = $customer->id;
+
+		$this->save();
+
+		// Next we will add the credit card to the user's account on Stripe using this
+		// token that was provided to this method. This will allow us to bill users
+		// when they subscribe to plans or we need to do one-off charges on them.
+		if (!is_null($token)) {
+			$this->updateCard($token);
+		}
+
+		return $customer;
+	}
+
+	/**
+	 * Get the Stripe customer for the Stripe model.
+	 *
+	 * @return \Stripe\Customer
+	 */
+	public function asStripeCustomer()
+	{
+		return StripeCustomer::retrieve($this->stripe_id, $this->getStripeKey());
+	}
+
+	/**
+	 * Get the Stripe supported currency used by the entity.
+	 *
+	 * @return string
+	 */
+	public function preferredCurrency()
+	{
+		return Cashier::usesCurrency();
+	}
+
+	/**
+	 * Get the tax percentage to apply to the subscription.
+	 *
+	 * @return int
+	 */
+	public function taxPercentage()
+	{
+		return 0;
+	}
+
+	/**
+	 * Get the Stripe API key.
+	 *
+	 * @return string
+	 */
+	public static function getStripeKey()
+	{
+		if (static::$stripeKey) {
+			return static::$stripeKey;
+		}
+
+		if ($key = getenv('STRIPE_SECRET')) {
+			return $key;
+		}
+
+		return config('services.stripe.secret');
+	}
+
+	/**
+	 * Set the Stripe API key.
+	 *
+	 * @param  string $key
+	 * @return void
+	 */
+	public static function setStripeKey($key)
+	{
+		static::$stripeKey = $key;
+	}
 }

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -91,7 +91,7 @@ trait Billable
     public function invoiceFor($description, $amount, array $options = [])
     {
         if (! $this->stripe_id) {
-            throw new InvalidArgumentException('User is not a customer. See the createAsStripeCustomer method.');
+            throw new InvalidArgumentException(class_basename($this).' is not a Stripe customer. See the createAsStripeCustomer method.');
         }
 
         $options = array_merge([
@@ -121,7 +121,7 @@ trait Billable
     }
 
     /**
-     * Determine if the user is on trial.
+     * Determine if the Stripe model is on trial.
      *
      * @param  string  $subscription
      * @param  string|null  $plan
@@ -144,7 +144,7 @@ trait Billable
     }
 
     /**
-     * Determine if the user is on a "generic" trial at the user level.
+     * Determine if the Stripe model is on a "generic" trial at the model level.
      *
      * @return bool
      */
@@ -154,7 +154,7 @@ trait Billable
     }
 
     /**
-     * Determine if the user has a given subscription.
+     * Determine if the Stripe model has a given subscription.
      *
      * @param  string  $subscription
      * @param  string|null  $plan
@@ -193,13 +193,13 @@ trait Billable
     }
 
     /**
-     * Get all of the subscriptions for the user.
+     * Get all of the subscriptions for the Stripe model.
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function subscriptions()
     {
-        return $this->hasMany(Subscription::class, 'user_id')->orderBy('created_at', 'desc');
+        return $this->hasMany(Subscription::class, $this->getForeignKey())->orderBy('created_at', 'desc');
     }
 
     /**
@@ -337,7 +337,7 @@ trait Billable
 
         // If the given token already has the card as their default source, we can just
         // bail out of the method now. We don't need to keep adding the same card to
-        // the user's account each time we go through this particular method call.
+        // the model's account each time we go through this particular method call.
         if ($token->card->id === $customer->default_source) {
             return;
         }
@@ -348,8 +348,8 @@ trait Billable
 
         $customer->save();
 
-        // Next, we will get the default source for this user so we can update the last
-        // four digits and the card brand on this user record in the database, which
+        // Next, we will get the default source for this model so we can update the last
+        // four digits and the card brand on this model's record in the database, which
         // is convenient when displaying on the front-end when updating the cards.
         $source = $customer->default_source
                     ? $customer->sources->retrieve($customer->default_source)
@@ -391,7 +391,7 @@ trait Billable
     }
 
     /**
-     * Fills the user's properties with the source from Stripe.
+     * Fills the model's properties with the source from Stripe.
      *
      * @param \Stripe\Card|null  $card
      * @return $this
@@ -422,7 +422,7 @@ trait Billable
     }
 
     /**
-     * Determine if the user is actively subscribed to one of the given plans.
+     * Determine if the Stripe model is actively subscribed to one of the given plans.
      *
      * @param  array|string  $plans
      * @param  string  $subscription
@@ -469,7 +469,7 @@ trait Billable
     }
 
     /**
-     * Create a Stripe customer for the given user.
+     * Create a Stripe customer for the given Stripe model.
      *
      * @param  string  $token
      * @param  array  $options
@@ -502,11 +502,11 @@ trait Billable
     }
 
     /**
-     * Get the Stripe customer for the user.
+     * Get the Stripe customer for the Stripe model.
      *
      * @return \Stripe\Customer
      */
-    public function asStripeCustomer()
+        public function asStripeCustomer()
     {
         return StripeCustomer::retrieve($this->stripe_id, $this->getStripeKey());
     }

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -17,546 +17,546 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 trait Billable
 {
-	/**
-	 * The Stripe API key.
-	 *
-	 * @var string
-	 */
-	protected static $stripeKey;
-
-	/**
-	 * Make a "one off" charge on the customer for the given amount.
-	 *
-	 * @param  int $amount
-	 * @param  array $options
-	 * @return \Stripe\Charge
-	 *
-	 * @throws \Stripe\Error\Card
-	 */
-	public function charge($amount, array $options = [])
-	{
-		$options = array_merge([
-			'currency' => $this->preferredCurrency(),
-		], $options);
-
-		$options['amount'] = $amount;
-
-		if (!array_key_exists('source', $options) && $this->stripe_id) {
-			$options['customer'] = $this->stripe_id;
-		}
-
-		if (!array_key_exists('source', $options) && !array_key_exists('customer', $options)) {
-			throw new InvalidArgumentException('No payment source provided.');
-		}
-
-		return StripeCharge::create($options, ['api_key' => $this->getStripeKey()]);
-	}
-
-	/**
-	 * Refund a customer for a charge.
-	 *
-	 * @param  string $charge
-	 * @param  array $options
-	 * @return \Stripe\Charge
-	 *
-	 * @throws \Stripe\Error\Refund
-	 */
-	public function refund($charge, array $options = [])
-	{
-		$options['charge'] = $charge;
-
-		return StripeRefund::create($options, ['api_key' => $this->getStripeKey()]);
-	}
-
-	/**
-	 * Determines if the customer currently has a card on file.
-	 *
-	 * @return bool
-	 */
-	public function hasCardOnFile()
-	{
-		return (bool)$this->card_brand;
-	}
-
-	/**
-	 * Invoice the customer for the given amount.
-	 *
-	 * @param  string $description
-	 * @param  int $amount
-	 * @param  array $options
-	 * @return bool
-	 *
-	 * @throws \Stripe\Error\Card
-	 */
-	public function invoiceFor($description, $amount, array $options = [])
-	{
-		if (!$this->stripe_id) {
-			throw new InvalidArgumentException(class_basename($this) . ' is not a Stripe customer. See the createAsStripeCustomer method.');
-		}
-
-		$options = array_merge([
-			'customer' => $this->stripe_id,
-			'amount' => $amount,
-			'currency' => $this->preferredCurrency(),
-			'description' => $description,
-		], $options);
-
-		StripeInvoiceItem::create(
-			$options, ['api_key' => $this->getStripeKey()]
-		);
-
-		return $this->invoice();
-	}
-
-	/**
-	 * Begin creating a new subscription.
-	 *
-	 * @param  string $subscription
-	 * @param  string $plan
-	 * @return \Laravel\Cashier\SubscriptionBuilder
-	 */
-	public function newSubscription($subscription, $plan)
-	{
-		return new SubscriptionBuilder($this, $subscription, $plan);
-	}
-
-	/**
-	 * Determine if the Stripe model is on trial.
-	 *
-	 * @param  string $subscription
-	 * @param  string|null $plan
-	 * @return bool
-	 */
-	public function onTrial($subscription = 'default', $plan = null)
-	{
-		if (func_num_args() === 0 && $this->onGenericTrial()) {
-			return true;
-		}
-
-		$subscription = $this->subscription($subscription);
-
-		if (is_null($plan)) {
-			return $subscription && $subscription->onTrial();
-		}
-
-		return $subscription && $subscription->onTrial() &&
-		$subscription->stripe_plan === $plan;
-	}
-
-	/**
-	 * Determine if the Stripe model is on a "generic" trial at the model level.
-	 *
-	 * @return bool
-	 */
-	public function onGenericTrial()
-	{
-		return $this->trial_ends_at && Carbon::now()->lt($this->trial_ends_at);
-	}
-
-	/**
-	 * Determine if the Stripe model has a given subscription.
-	 *
-	 * @param  string $subscription
-	 * @param  string|null $plan
-	 * @return bool
-	 */
-	public function subscribed($subscription = 'default', $plan = null)
-	{
-		$subscription = $this->subscription($subscription);
-
-		if (is_null($subscription)) {
-			return false;
-		}
-
-		if (is_null($plan)) {
-			return $subscription->valid();
-		}
-
-		return $subscription->valid() &&
-		$subscription->stripe_plan === $plan;
-	}
-
-	/**
-	 * Get a subscription instance by name.
-	 *
-	 * @param  string $subscription
-	 * @return \Laravel\Cashier\Subscription|null
-	 */
-	public function subscription($subscription = 'default')
-	{
-		return $this->subscriptions->sortByDesc(function ($value) {
-			return $value->created_at->getTimestamp();
-		})
-			->first(function ($value) use ($subscription) {
-				return $value->name === $subscription;
-			});
-	}
-
-	/**
-	 * Get all of the subscriptions for the Stripe model.
-	 *
-	 * @return \Illuminate\Database\Eloquent\Collection
-	 */
-	public function subscriptions()
-	{
-		return $this->hasMany(Subscription::class, $this->getForeignKey())->orderBy('created_at', 'desc');
-	}
-
-	/**
-	 * Invoice the billable entity outside of regular billing cycle.
-	 *
-	 * @return StripeInvoice|bool
-	 */
-	public function invoice()
-	{
-		if ($this->stripe_id) {
-			try {
-				return StripeInvoice::create(['customer' => $this->stripe_id], $this->getStripeKey())->pay();
-			} catch (StripeErrorInvalidRequest $e) {
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * Get the entity's upcoming invoice.
-	 *
-	 * @return \Laravel\Cashier\Invoice|null
-	 */
-	public function upcomingInvoice()
-	{
-		try {
-			$stripeInvoice = StripeInvoice::upcoming(
-				['customer' => $this->stripe_id], ['api_key' => $this->getStripeKey()]
-			);
-
-			return new Invoice($this, $stripeInvoice);
-		} catch (StripeErrorInvalidRequest $e) {
-			//
-		}
-	}
-
-	/**
-	 * Find an invoice by ID.
-	 *
-	 * @param  string $id
-	 * @return \Laravel\Cashier\Invoice|null
-	 */
-	public function findInvoice($id)
-	{
-		try {
-			return new Invoice($this, StripeInvoice::retrieve($id, $this->getStripeKey()));
-		} catch (Exception $e) {
-			//
-		}
-	}
-
-	/**
-	 * Find an invoice or throw a 404 error.
-	 *
-	 * @param  string $id
-	 * @return \Laravel\Cashier\Invoice
-	 */
-	public function findInvoiceOrFail($id)
-	{
-		$invoice = $this->findInvoice($id);
-
-		if (is_null($invoice)) {
-			throw new NotFoundHttpException;
-		}
-
-		return $invoice;
-	}
-
-	/**
-	 * Create an invoice download Response.
-	 *
-	 * @param  string $id
-	 * @param  array $data
-	 * @param  string $storagePath
-	 * @return \Symfony\Component\HttpFoundation\Response
-	 */
-	public function downloadInvoice($id, array $data, $storagePath = null)
-	{
-		return $this->findInvoiceOrFail($id)->download($data, $storagePath);
-	}
-
-	/**
-	 * Get a collection of the entity's invoices.
-	 *
-	 * @param  bool $includePending
-	 * @param  array $parameters
-	 * @return \Illuminate\Support\Collection
-	 */
-	public function invoices($includePending = false, $parameters = [])
-	{
-		$invoices = [];
-
-		$parameters = array_merge(['limit' => 24], $parameters);
-
-		$stripeInvoices = $this->asStripeCustomer()->invoices($parameters);
-
-		// Here we will loop through the Stripe invoices and create our own custom Invoice
-		// instances that have more helper methods and are generally more convenient to
-		// work with than the plain Stripe objects are. Then, we'll return the array.
-		if (!is_null($stripeInvoices)) {
-			foreach ($stripeInvoices->data as $invoice) {
-				if ($invoice->paid || $includePending) {
-					$invoices[] = new Invoice($this, $invoice);
-				}
-			}
-		}
-
-		return new Collection($invoices);
-	}
-
-	/**
-	 * Get an array of the entity's invoices.
-	 *
-	 * @param  array $parameters
-	 * @return \Illuminate\Support\Collection
-	 */
-	public function invoicesIncludingPending(array $parameters = [])
-	{
-		return $this->invoices(true, $parameters);
-	}
-
-	/**
-	 * Update customer's credit card.
-	 *
-	 * @param  string $token
-	 * @return void
-	 */
-	public function updateCard($token)
-	{
-		$customer = $this->asStripeCustomer();
-
-		$token = StripeToken::retrieve($token, ['api_key' => $this->getStripeKey()]);
-
-		// If the given token already has the card as their default source, we can just
-		// bail out of the method now. We don't need to keep adding the same card to
-		// the model's account each time we go through this particular method call.
-		if ($token->card->id === $customer->default_source) {
-			return;
-		}
-
-		$card = $customer->sources->create(['source' => $token]);
-
-		$customer->default_source = $card->id;
-
-		$customer->save();
-
-		// Next, we will get the default source for this model so we can update the last
-		// four digits and the card brand on this model's record in the database, which
-		// is convenient when displaying on the front-end when updating the cards.
-		$source = $customer->default_source
-			? $customer->sources->retrieve($customer->default_source)
-			: null;
-
-		$this->fillCardDetails($source);
-
-		$this->save();
-	}
-
-	/**
-	 * Synchronises the customer's card from Stripe back into the database.
-	 *
-	 * @return $this
-	 */
-	public function updateCardFromStripe()
-	{
-		$customer = $this->asStripeCustomer();
-
-		$defaultCard = null;
-
-		foreach ($customer->sources->data as $card) {
-			if ($card->id === $customer->default_source) {
-				$defaultCard = $card;
-				break;
-			}
-		}
-
-		if ($defaultCard) {
-			$this->fillCardDetails($defaultCard)->save();
-		} else {
-			$this->forceFill([
-				'card_brand' => null,
-				'card_last_four' => null,
-			])->save();
-		}
-
-		return $this;
-	}
-
-	/**
-	 * Fills the model's properties with the source from Stripe.
-	 *
-	 * @param \Stripe\Card|null $card
-	 * @return $this
-	 */
-	protected function fillCardDetails($card)
-	{
-		if ($card) {
-			$this->card_brand = $card->brand;
-			$this->card_last_four = $card->last4;
-		}
-
-		return $this;
-	}
-
-	/**
-	 * Apply a coupon to the billable entity.
-	 *
-	 * @param  string $coupon
-	 * @return void
-	 */
-	public function applyCoupon($coupon)
-	{
-		$customer = $this->asStripeCustomer();
-
-		$customer->coupon = $coupon;
-
-		$customer->save();
-	}
-
-	/**
-	 * Determine if the Stripe model is actively subscribed to one of the given plans.
-	 *
-	 * @param  array|string $plans
-	 * @param  string $subscription
-	 * @return bool
-	 */
-	public function subscribedToPlan($plans, $subscription = 'default')
-	{
-		$subscription = $this->subscription($subscription);
-
-		if (!$subscription || !$subscription->valid()) {
-			return false;
-		}
-
-		foreach ((array)$plans as $plan) {
-			if ($subscription->stripe_plan === $plan) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Determine if the entity is on the given plan.
-	 *
-	 * @param  string $plan
-	 * @return bool
-	 */
-	public function onPlan($plan)
-	{
-		return !is_null($this->subscriptions->first(function ($value) use ($plan) {
-			return $value->stripe_plan === $plan && $value->valid();
-		}));
-	}
-
-	/**
-	 * Determine if the entity has a Stripe customer ID.
-	 *
-	 * @return bool
-	 */
-	public function hasStripeId()
-	{
-		return !is_null($this->stripe_id);
-	}
-
-	/**
-	 * Create a Stripe customer for the given Stripe model.
-	 *
-	 * @param  string $token
-	 * @param  array $options
-	 * @return StripeCustomer
-	 */
-	public function createAsStripeCustomer($token, array $options = [])
-	{
-		$options = array_key_exists('email', $options)
-			? $options : array_merge($options, ['email' => $this->email]);
-
-		// Here we will create the customer instance on Stripe and store the ID of the
-		// user from Stripe. This ID will correspond with the Stripe user instances
-		// and allow us to retrieve users from Stripe later when we need to work.
-		$customer = StripeCustomer::create(
-			$options, $this->getStripeKey()
-		);
-
-		$this->stripe_id = $customer->id;
-
-		$this->save();
-
-		// Next we will add the credit card to the user's account on Stripe using this
-		// token that was provided to this method. This will allow us to bill users
-		// when they subscribe to plans or we need to do one-off charges on them.
-		if (!is_null($token)) {
-			$this->updateCard($token);
-		}
-
-		return $customer;
-	}
-
-	/**
-	 * Get the Stripe customer for the Stripe model.
-	 *
-	 * @return \Stripe\Customer
-	 */
-	public function asStripeCustomer()
-	{
-		return StripeCustomer::retrieve($this->stripe_id, $this->getStripeKey());
-	}
-
-	/**
-	 * Get the Stripe supported currency used by the entity.
-	 *
-	 * @return string
-	 */
-	public function preferredCurrency()
-	{
-		return Cashier::usesCurrency();
-	}
-
-	/**
-	 * Get the tax percentage to apply to the subscription.
-	 *
-	 * @return int
-	 */
-	public function taxPercentage()
-	{
-		return 0;
-	}
-
-	/**
-	 * Get the Stripe API key.
-	 *
-	 * @return string
-	 */
-	public static function getStripeKey()
-	{
-		if (static::$stripeKey) {
-			return static::$stripeKey;
-		}
-
-		if ($key = getenv('STRIPE_SECRET')) {
-			return $key;
-		}
-
-		return config('services.stripe.secret');
-	}
-
-	/**
-	 * Set the Stripe API key.
-	 *
-	 * @param  string $key
-	 * @return void
-	 */
-	public static function setStripeKey($key)
-	{
-		static::$stripeKey = $key;
-	}
+    /**
+     * The Stripe API key.
+     *
+     * @var string
+     */
+    protected static $stripeKey;
+
+    /**
+     * Make a "one off" charge on the customer for the given amount.
+     *
+     * @param  int  $amount
+     * @param  array  $options
+     * @return \Stripe\Charge
+     *
+     * @throws \Stripe\Error\Card
+     */
+    public function charge($amount, array $options = [])
+    {
+        $options = array_merge([
+            'currency' => $this->preferredCurrency(),
+        ], $options);
+
+        $options['amount'] = $amount;
+
+        if (! array_key_exists('source', $options) && $this->stripe_id) {
+            $options['customer'] = $this->stripe_id;
+        }
+
+        if (! array_key_exists('source', $options) && ! array_key_exists('customer', $options)) {
+            throw new InvalidArgumentException('No payment source provided.');
+        }
+
+        return StripeCharge::create($options, ['api_key' => $this->getStripeKey()]);
+    }
+
+    /**
+     * Refund a customer for a charge.
+     *
+     * @param  string  $charge
+     * @param  array  $options
+     * @return \Stripe\Charge
+     *
+     * @throws \Stripe\Error\Refund
+     */
+    public function refund($charge, array $options = [])
+    {
+        $options['charge'] = $charge;
+
+        return StripeRefund::create($options, ['api_key' => $this->getStripeKey()]);
+    }
+
+    /**
+     * Determines if the customer currently has a card on file.
+     *
+     * @return bool
+     */
+    public function hasCardOnFile()
+    {
+        return (bool) $this->card_brand;
+    }
+
+    /**
+     * Invoice the customer for the given amount.
+     *
+     * @param  string  $description
+     * @param  int  $amount
+     * @param  array  $options
+     * @return bool
+     *
+     * @throws \Stripe\Error\Card
+     */
+    public function invoiceFor($description, $amount, array $options = [])
+    {
+        if (! $this->stripe_id) {
+            throw new InvalidArgumentException(class_basename($this).' is not a Stripe customer. See the createAsStripeCustomer method.');
+        }
+
+        $options = array_merge([
+            'customer' => $this->stripe_id,
+            'amount' => $amount,
+            'currency' => $this->preferredCurrency(),
+            'description' => $description,
+        ], $options);
+
+        StripeInvoiceItem::create(
+            $options, ['api_key' => $this->getStripeKey()]
+        );
+
+        return $this->invoice();
+    }
+
+    /**
+     * Begin creating a new subscription.
+     *
+     * @param  string  $subscription
+     * @param  string  $plan
+     * @return \Laravel\Cashier\SubscriptionBuilder
+     */
+    public function newSubscription($subscription, $plan)
+    {
+        return new SubscriptionBuilder($this, $subscription, $plan);
+    }
+
+    /**
+     * Determine if the Stripe model is on trial.
+     *
+     * @param  string  $subscription
+     * @param  string|null  $plan
+     * @return bool
+     */
+    public function onTrial($subscription = 'default', $plan = null)
+    {
+        if (func_num_args() === 0 && $this->onGenericTrial()) {
+            return true;
+        }
+
+        $subscription = $this->subscription($subscription);
+
+        if (is_null($plan)) {
+            return $subscription && $subscription->onTrial();
+        }
+
+        return $subscription && $subscription->onTrial() &&
+               $subscription->stripe_plan === $plan;
+    }
+
+    /**
+     * Determine if the Stripe model is on a "generic" trial at the model level.
+     *
+     * @return bool
+     */
+    public function onGenericTrial()
+    {
+        return $this->trial_ends_at && Carbon::now()->lt($this->trial_ends_at);
+    }
+
+    /**
+     * Determine if the Stripe model has a given subscription.
+     *
+     * @param  string  $subscription
+     * @param  string|null  $plan
+     * @return bool
+     */
+    public function subscribed($subscription = 'default', $plan = null)
+    {
+        $subscription = $this->subscription($subscription);
+
+        if (is_null($subscription)) {
+            return false;
+        }
+
+        if (is_null($plan)) {
+            return $subscription->valid();
+        }
+
+        return $subscription->valid() &&
+               $subscription->stripe_plan === $plan;
+    }
+
+    /**
+     * Get a subscription instance by name.
+     *
+     * @param  string  $subscription
+     * @return \Laravel\Cashier\Subscription|null
+     */
+    public function subscription($subscription = 'default')
+    {
+        return $this->subscriptions->sortByDesc(function ($value) {
+            return $value->created_at->getTimestamp();
+        })
+        ->first(function ($value) use ($subscription) {
+            return $value->name === $subscription;
+        });
+    }
+
+    /**
+     * Get all of the subscriptions for the Stripe model.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function subscriptions()
+    {
+        return $this->hasMany(Subscription::class, $this->getForeignKey())->orderBy('created_at', 'desc');
+    }
+
+    /**
+     * Invoice the billable entity outside of regular billing cycle.
+     *
+     * @return StripeInvoice|bool
+     */
+    public function invoice()
+    {
+        if ($this->stripe_id) {
+            try {
+                return StripeInvoice::create(['customer' => $this->stripe_id], $this->getStripeKey())->pay();
+            } catch (StripeErrorInvalidRequest $e) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the entity's upcoming invoice.
+     *
+     * @return \Laravel\Cashier\Invoice|null
+     */
+    public function upcomingInvoice()
+    {
+        try {
+            $stripeInvoice = StripeInvoice::upcoming(
+                ['customer' => $this->stripe_id], ['api_key' => $this->getStripeKey()]
+            );
+
+            return new Invoice($this, $stripeInvoice);
+        } catch (StripeErrorInvalidRequest $e) {
+            //
+        }
+    }
+
+    /**
+     * Find an invoice by ID.
+     *
+     * @param  string  $id
+     * @return \Laravel\Cashier\Invoice|null
+     */
+    public function findInvoice($id)
+    {
+        try {
+            return new Invoice($this, StripeInvoice::retrieve($id, $this->getStripeKey()));
+        } catch (Exception $e) {
+            //
+        }
+    }
+
+    /**
+     * Find an invoice or throw a 404 error.
+     *
+     * @param  string  $id
+     * @return \Laravel\Cashier\Invoice
+     */
+    public function findInvoiceOrFail($id)
+    {
+        $invoice = $this->findInvoice($id);
+
+        if (is_null($invoice)) {
+            throw new NotFoundHttpException;
+        }
+
+        return $invoice;
+    }
+
+    /**
+     * Create an invoice download Response.
+     *
+     * @param  string  $id
+     * @param  array   $data
+     * @param  string  $storagePath
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function downloadInvoice($id, array $data, $storagePath = null)
+    {
+        return $this->findInvoiceOrFail($id)->download($data, $storagePath);
+    }
+
+    /**
+     * Get a collection of the entity's invoices.
+     *
+     * @param  bool  $includePending
+     * @param  array  $parameters
+     * @return \Illuminate\Support\Collection
+     */
+    public function invoices($includePending = false, $parameters = [])
+    {
+        $invoices = [];
+
+        $parameters = array_merge(['limit' => 24], $parameters);
+
+        $stripeInvoices = $this->asStripeCustomer()->invoices($parameters);
+
+        // Here we will loop through the Stripe invoices and create our own custom Invoice
+        // instances that have more helper methods and are generally more convenient to
+        // work with than the plain Stripe objects are. Then, we'll return the array.
+        if (! is_null($stripeInvoices)) {
+            foreach ($stripeInvoices->data as $invoice) {
+                if ($invoice->paid || $includePending) {
+                    $invoices[] = new Invoice($this, $invoice);
+                }
+            }
+        }
+
+        return new Collection($invoices);
+    }
+
+    /**
+     * Get an array of the entity's invoices.
+     *
+     * @param  array  $parameters
+     * @return \Illuminate\Support\Collection
+     */
+    public function invoicesIncludingPending(array $parameters = [])
+    {
+        return $this->invoices(true, $parameters);
+    }
+
+    /**
+     * Update customer's credit card.
+     *
+     * @param  string  $token
+     * @return void
+     */
+    public function updateCard($token)
+    {
+        $customer = $this->asStripeCustomer();
+
+        $token = StripeToken::retrieve($token, ['api_key' => $this->getStripeKey()]);
+
+        // If the given token already has the card as their default source, we can just
+        // bail out of the method now. We don't need to keep adding the same card to
+        // the model's account each time we go through this particular method call.
+        if ($token->card->id === $customer->default_source) {
+            return;
+        }
+
+        $card = $customer->sources->create(['source' => $token]);
+
+        $customer->default_source = $card->id;
+
+        $customer->save();
+
+        // Next, we will get the default source for this model so we can update the last
+        // four digits and the card brand on this model's record in the database, which
+        // is convenient when displaying on the front-end when updating the cards.
+        $source = $customer->default_source
+                    ? $customer->sources->retrieve($customer->default_source)
+                    : null;
+
+        $this->fillCardDetails($source);
+
+        $this->save();
+    }
+
+    /**
+     * Synchronises the customer's card from Stripe back into the database.
+     *
+     * @return $this
+     */
+    public function updateCardFromStripe()
+    {
+        $customer = $this->asStripeCustomer();
+
+        $defaultCard = null;
+
+        foreach ($customer->sources->data as $card) {
+            if ($card->id === $customer->default_source) {
+                $defaultCard = $card;
+                break;
+            }
+        }
+
+        if ($defaultCard) {
+            $this->fillCardDetails($defaultCard)->save();
+        } else {
+            $this->forceFill([
+                'card_brand' => null,
+                'card_last_four' => null,
+            ])->save();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Fills the model's properties with the source from Stripe.
+     *
+     * @param \Stripe\Card|null  $card
+     * @return $this
+     */
+    protected function fillCardDetails($card)
+    {
+        if ($card) {
+            $this->card_brand = $card->brand;
+            $this->card_last_four = $card->last4;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply a coupon to the billable entity.
+     *
+     * @param  string  $coupon
+     * @return void
+     */
+    public function applyCoupon($coupon)
+    {
+        $customer = $this->asStripeCustomer();
+
+        $customer->coupon = $coupon;
+
+        $customer->save();
+    }
+
+    /**
+     * Determine if the Stripe model is actively subscribed to one of the given plans.
+     *
+     * @param  array|string  $plans
+     * @param  string  $subscription
+     * @return bool
+     */
+    public function subscribedToPlan($plans, $subscription = 'default')
+    {
+        $subscription = $this->subscription($subscription);
+
+        if (! $subscription || ! $subscription->valid()) {
+            return false;
+        }
+
+        foreach ((array) $plans as $plan) {
+            if ($subscription->stripe_plan === $plan) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if the entity is on the given plan.
+     *
+     * @param  string  $plan
+     * @return bool
+     */
+    public function onPlan($plan)
+    {
+        return ! is_null($this->subscriptions->first(function ($value) use ($plan) {
+            return $value->stripe_plan === $plan && $value->valid();
+        }));
+    }
+
+    /**
+     * Determine if the entity has a Stripe customer ID.
+     *
+     * @return bool
+     */
+    public function hasStripeId()
+    {
+        return ! is_null($this->stripe_id);
+    }
+
+    /**
+     * Create a Stripe customer for the given Stripe model.
+     *
+     * @param  string  $token
+     * @param  array  $options
+     * @return StripeCustomer
+     */
+    public function createAsStripeCustomer($token, array $options = [])
+    {
+        $options = array_key_exists('email', $options)
+                ? $options : array_merge($options, ['email' => $this->email]);
+
+        // Here we will create the customer instance on Stripe and store the ID of the
+        // user from Stripe. This ID will correspond with the Stripe user instances
+        // and allow us to retrieve users from Stripe later when we need to work.
+        $customer = StripeCustomer::create(
+            $options, $this->getStripeKey()
+        );
+
+        $this->stripe_id = $customer->id;
+
+        $this->save();
+
+        // Next we will add the credit card to the user's account on Stripe using this
+        // token that was provided to this method. This will allow us to bill users
+        // when they subscribe to plans or we need to do one-off charges on them.
+        if (! is_null($token)) {
+            $this->updateCard($token);
+        }
+
+        return $customer;
+    }
+
+    /**
+     * Get the Stripe customer for the Stripe model.
+     *
+     * @return \Stripe\Customer
+     */
+    public function asStripeCustomer()
+    {
+        return StripeCustomer::retrieve($this->stripe_id, $this->getStripeKey());
+    }
+
+    /**
+     * Get the Stripe supported currency used by the entity.
+     *
+     * @return string
+     */
+    public function preferredCurrency()
+    {
+        return Cashier::usesCurrency();
+    }
+
+    /**
+     * Get the tax percentage to apply to the subscription.
+     *
+     * @return int
+     */
+    public function taxPercentage()
+    {
+        return 0;
+    }
+
+    /**
+     * Get the Stripe API key.
+     *
+     * @return string
+     */
+    public static function getStripeKey()
+    {
+        if (static::$stripeKey) {
+            return static::$stripeKey;
+        }
+
+        if ($key = getenv('STRIPE_SECRET')) {
+            return $key;
+        }
+
+        return config('services.stripe.secret');
+    }
+
+    /**
+     * Set the Stripe API key.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public static function setStripeKey($key)
+    {
+        static::$stripeKey = $key;
+    }
 }

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -28,7 +28,7 @@ class Cashier
     protected static $formatCurrencyUsing;
 
     /**
-     * Set the currency to be used when billing users.
+     * Set the currency to be used when billing Stripe models.
      *
      * @param  string  $currency
      * @param  string|null  $symbol

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -234,7 +234,7 @@ class Invoice
     public function view(array $data)
     {
         return View::make('cashier::receipt', array_merge(
-            $data, ['invoice' => $this, 'owner' => $this->owner]
+            $data, ['invoice' => $this, 'owner' => $this->owner, 'user' => $this->owner]
         ));
     }
 

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -11,11 +11,11 @@ use Symfony\Component\HttpFoundation\Response;
 class Invoice
 {
     /**
-     * The user instance.
+     * The Stripe model instance.
      *
      * @var \Illuminate\Database\Eloquent\Model
      */
-    protected $user;
+    protected $owner;
 
     /**
      * The Stripe invoice instance.
@@ -27,13 +27,13 @@ class Invoice
     /**
      * Create a new invoice instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $user
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
      * @param  \Stripe\Invoice  $invoice
      * @return void
      */
-    public function __construct($user, StripeInvoice $invoice)
+    public function __construct($owner, StripeInvoice $invoice)
     {
-        $this->user = $user;
+        $this->owner = $owner;
         $this->invoice = $invoice;
     }
 
@@ -206,7 +206,7 @@ class Invoice
         if (isset($this->lines->data)) {
             foreach ($this->lines->data as $line) {
                 if ($line->type == $type) {
-                    $lineItems[] = new InvoiceItem($this->user, $line);
+                    $lineItems[] = new InvoiceItem($this->owner, $line);
                 }
             }
         }
@@ -215,7 +215,7 @@ class Invoice
     }
 
     /**
-     * Format the given amount into a string based on the user's preferences.
+     * Format the given amount into a string based on the Stripe model's preferences.
      *
      * @param  int  $amount
      * @return string
@@ -234,7 +234,7 @@ class Invoice
     public function view(array $data)
     {
         return View::make('cashier::receipt', array_merge(
-            $data, ['invoice' => $this, 'user' => $this->user]
+            $data, ['invoice' => $this, 'owner' => $this->owner]
         ));
     }
 

--- a/src/InvoiceItem.php
+++ b/src/InvoiceItem.php
@@ -7,11 +7,11 @@ use Carbon\Carbon;
 class InvoiceItem
 {
     /**
-     * The user instance.
+     * The Stripe model instance.
      *
      * @var \Illuminate\Database\Eloquent\Model
      */
-    protected $user;
+    protected $owner;
 
     /**
      * The Stripe invoice item instance.
@@ -23,13 +23,13 @@ class InvoiceItem
     /**
      * Create a new invoice item instance.
      *
-     * @param  \Illuminate\Database\Eloquent\User  $user
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
      * @param  \Stripe\StripeObject  $item
      * @return void
      */
-    public function __construct($user, $item)
+    public function __construct($owner, $item)
     {
-        $this->user = $user;
+        $this->owner = $owner;
         $this->item = $item;
     }
 
@@ -102,7 +102,7 @@ class InvoiceItem
     }
 
     /**
-     * Format the given amount into a string based on the user's preferences.
+     * Format the given amount into a string based on the owner model's preferences.
      *
      * @param  int  $amount
      * @return string

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -5,7 +5,6 @@ namespace Laravel\Cashier;
 use Carbon\Carbon;
 use LogicException;
 use DateTimeInterface;
-use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 
 class Subscription extends Model

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -10,351 +10,348 @@ use Illuminate\Database\Eloquent\Model;
 
 class Subscription extends Model
 {
-	/**
-	 * The attributes that aren't mass assignable.
-	 *
-	 * @var array
-	 */
-	protected $guarded = [];
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
 
-	/**
-	 * The attributes that should be mutated to dates.
-	 *
-	 * @var array
-	 */
-	protected $dates = [
-		'trial_ends_at',
-		'ends_at',
-		'created_at',
-		'updated_at',
-	];
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'trial_ends_at', 'ends_at',
+        'created_at', 'updated_at',
+    ];
 
-	/**
-	 * Indicates if the plan change should be prorated.
-	 *
-	 * @var bool
-	 */
-	protected $prorate = true;
+    /**
+     * Indicates if the plan change should be prorated.
+     *
+     * @var bool
+     */
+    protected $prorate = true;
 
-	/**
-	 * The date on which the billing cycle should be anchored.
-	 *
-	 * @var string|null
-	 */
-	protected $billingCycleAnchor = null;
+    /**
+     * The date on which the billing cycle should be anchored.
+     *
+     * @var string|null
+     */
+    protected $billingCycleAnchor = null;
 
-	/**
-	 * Get the user that owns the subscription.
-	 * (Backwards compatibility)
-	 */
-	public function user()
-	{
-		return $this->owner();
-	}
+    /**
+	 * Get the user that owns the subscription (Backwards compatibility)
+     */
+    public function user()
+    {
+        return $this->owner();
+    }
 
-	/**
-	 * Get the model related to the subscription
-	 */
-	public function owner()
-	{
-		$model = getenv('STRIPE_MODEL') ?: config('services.stripe.model', 'User');
-		$foreignKey = Str::snake(class_basename($model)) . '_id';
+    /**
+     * Get the model related to the subscription
+     */
+    public function owner()
+    {
+        $model = getenv('STRIPE_MODEL') ?: config('services.stripe.model', 'User');
+        $foreignKey = Str::snake(class_basename($model)).'_id';
 
-		return $this->belongsTo($model, $foreignKey);
-	}
+        return $this->belongsTo($model, $foreignKey);
+    }
 
-	/**
-	 * Determine if the subscription is active, on trial, or within its grace period.
-	 *
-	 * @return bool
-	 */
-	public function valid()
-	{
-		return $this->active() || $this->onTrial() || $this->onGracePeriod();
-	}
+    /**
+     * Determine if the subscription is active, on trial, or within its grace period.
+     *
+     * @return bool
+     */
+    public function valid()
+    {
+        return $this->active() || $this->onTrial() || $this->onGracePeriod();
+    }
 
-	/**
-	 * Determine if the subscription is active.
-	 *
-	 * @return bool
-	 */
-	public function active()
-	{
-		return is_null($this->ends_at) || $this->onGracePeriod();
-	}
+    /**
+     * Determine if the subscription is active.
+     *
+     * @return bool
+     */
+    public function active()
+    {
+        return is_null($this->ends_at) || $this->onGracePeriod();
+    }
 
-	/**
-	 * Determine if the subscription is no longer active.
-	 *
-	 * @return bool
-	 */
-	public function cancelled()
-	{
-		return !is_null($this->ends_at);
-	}
+    /**
+     * Determine if the subscription is no longer active.
+     *
+     * @return bool
+     */
+    public function cancelled()
+    {
+        return ! is_null($this->ends_at);
+    }
 
-	/**
-	 * Determine if the subscription is within its trial period.
-	 *
-	 * @return bool
-	 */
-	public function onTrial()
-	{
-		if (!is_null($this->trial_ends_at)) {
-			return Carbon::today()->lt($this->trial_ends_at);
-		} else {
-			return false;
-		}
-	}
+    /**
+     * Determine if the subscription is within its trial period.
+     *
+     * @return bool
+     */
+    public function onTrial()
+    {
+        if (! is_null($this->trial_ends_at)) {
+            return Carbon::today()->lt($this->trial_ends_at);
+        } else {
+            return false;
+        }
+    }
 
-	/**
-	 * Determine if the subscription is within its grace period after cancellation.
-	 *
-	 * @return bool
-	 */
-	public function onGracePeriod()
-	{
-		if (!is_null($endsAt = $this->ends_at)) {
-			return Carbon::now()->lt(Carbon::instance($endsAt));
-		} else {
-			return false;
-		}
-	}
+    /**
+     * Determine if the subscription is within its grace period after cancellation.
+     *
+     * @return bool
+     */
+    public function onGracePeriod()
+    {
+        if (! is_null($endsAt = $this->ends_at)) {
+            return Carbon::now()->lt(Carbon::instance($endsAt));
+        } else {
+            return false;
+        }
+    }
 
-	/**
-	 * Increment the quantity of the subscription.
-	 *
-	 * @param  int $count
-	 * @return $this
-	 */
-	public function incrementQuantity($count = 1)
-	{
-		$this->updateQuantity($this->quantity + $count);
+    /**
+     * Increment the quantity of the subscription.
+     *
+     * @param  int  $count
+     * @return $this
+     */
+    public function incrementQuantity($count = 1)
+    {
+        $this->updateQuantity($this->quantity + $count);
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 *  Increment the quantity of the subscription, and invoice immediately.
-	 *
-	 * @param  int $count
-	 * @return $this
-	 */
-	public function incrementAndInvoice($count = 1)
-	{
-		$this->incrementQuantity($count);
+    /**
+     *  Increment the quantity of the subscription, and invoice immediately.
+     *
+     * @param  int  $count
+     * @return $this
+     */
+    public function incrementAndInvoice($count = 1)
+    {
+        $this->incrementQuantity($count);
 
-		$this->user->invoice();
+        $this->user->invoice();
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Decrement the quantity of the subscription.
-	 *
-	 * @param  int $count
-	 * @return $this
-	 */
-	public function decrementQuantity($count = 1)
-	{
-		$this->updateQuantity(max(1, $this->quantity - $count));
+    /**
+     * Decrement the quantity of the subscription.
+     *
+     * @param  int  $count
+     * @return $this
+     */
+    public function decrementQuantity($count = 1)
+    {
+        $this->updateQuantity(max(1, $this->quantity - $count));
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Update the quantity of the subscription.
-	 *
-	 * @param  int $quantity
-	 * @param  \Stripe\Customer|null $customer
-	 * @return $this
-	 */
-	public function updateQuantity($quantity, $customer = null)
-	{
-		$subscription = $this->asStripeSubscription();
+    /**
+     * Update the quantity of the subscription.
+     *
+     * @param  int  $quantity
+     * @param  \Stripe\Customer|null  $customer
+     * @return $this
+     */
+    public function updateQuantity($quantity, $customer = null)
+    {
+        $subscription = $this->asStripeSubscription();
 
-		$subscription->quantity = $quantity;
+        $subscription->quantity = $quantity;
 
-		$subscription->save();
+        $subscription->save();
 
-		$this->quantity = $quantity;
+        $this->quantity = $quantity;
 
-		$this->save();
+        $this->save();
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Indicate that the plan change should not be prorated.
-	 *
-	 * @return $this
-	 */
-	public function noProrate()
-	{
-		$this->prorate = false;
+    /**
+     * Indicate that the plan change should not be prorated.
+     *
+     * @return $this
+     */
+    public function noProrate()
+    {
+        $this->prorate = false;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Change the billing cycle anchor on a plan change.
-	 *
-	 * @param  int|string $date
-	 * @return $this
-	 */
-	public function anchorBillingCycleOn($date = 'now')
-	{
-		if ($date instanceof DateTimeInterface) {
-			$date = $date->getTimestamp();
-		}
+    /**
+     * Change the billing cycle anchor on a plan change.
+     *
+     * @param  int|string  $date
+     * @return $this
+     */
+    public function anchorBillingCycleOn($date = 'now')
+    {
+        if ($date instanceof DateTimeInterface) {
+            $date = $date->getTimestamp();
+        }
 
-		$this->billingCycleAnchor = $date;
+        $this->billingCycleAnchor = $date;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Swap the subscription to a new Stripe plan.
-	 *
-	 * @param  string $plan
-	 * @return $this
-	 */
-	public function swap($plan)
-	{
-		$subscription = $this->asStripeSubscription();
+    /**
+     * Swap the subscription to a new Stripe plan.
+     *
+     * @param  string  $plan
+     * @return $this
+     */
+    public function swap($plan)
+    {
+        $subscription = $this->asStripeSubscription();
 
-		$subscription->plan = $plan;
+        $subscription->plan = $plan;
 
-		$subscription->prorate = $this->prorate;
+        $subscription->prorate = $this->prorate;
 
-		if (!is_null($this->billingCycleAnchor)) {
-			$subscription->billingCycleAnchor = $this->billingCycleAnchor;
-		}
+        if (! is_null($this->billingCycleAnchor)) {
+            $subscription->billingCycleAnchor = $this->billingCycleAnchor;
+        }
 
-		// If no specific trial end date has been set, the default behavior should be
-		// to maintain the current trial state, whether that is "active" or to run
-		// the swap out with the exact number of days left on this current plan.
-		if ($this->onTrial()) {
-			$subscription->trial_end = $this->trial_ends_at->getTimestamp();
-		} else {
-			$subscription->trial_end = 'now';
-		}
+        // If no specific trial end date has been set, the default behavior should be
+        // to maintain the current trial state, whether that is "active" or to run
+        // the swap out with the exact number of days left on this current plan.
+        if ($this->onTrial()) {
+            $subscription->trial_end = $this->trial_ends_at->getTimestamp();
+        } else {
+            $subscription->trial_end = 'now';
+        }
 
-		// Again, if no explicit quantity was set, the default behaviors should be to
-		// maintain the current quantity onto the new plan. This is a sensible one
-		// that should be the expected behavior for most developers with Stripe.
-		if ($this->quantity) {
-			$subscription->quantity = $this->quantity;
-		}
+        // Again, if no explicit quantity was set, the default behaviors should be to
+        // maintain the current quantity onto the new plan. This is a sensible one
+        // that should be the expected behavior for most developers with Stripe.
+        if ($this->quantity) {
+            $subscription->quantity = $this->quantity;
+        }
 
-		$subscription->save();
+        $subscription->save();
 
-		$this->user->invoice();
+        $this->user->invoice();
 
-		$this->fill([
-			'stripe_plan' => $plan,
-			'ends_at' => null,
-		])->save();
+        $this->fill([
+            'stripe_plan' => $plan,
+            'ends_at' => null,
+        ])->save();
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Cancel the subscription at the end of the billing period.
-	 *
-	 * @return $this
-	 */
-	public function cancel()
-	{
-		$subscription = $this->asStripeSubscription();
+    /**
+     * Cancel the subscription at the end of the billing period.
+     *
+     * @return $this
+     */
+    public function cancel()
+    {
+        $subscription = $this->asStripeSubscription();
 
-		$subscription->cancel(['at_period_end' => true]);
+        $subscription->cancel(['at_period_end' => true]);
 
-		// If the user was on trial, we will set the grace period to end when the trial
-		// would have ended. Otherwise, we'll retrieve the end of the billing period
-		// period and make that the end of the grace period for this current user.
-		if ($this->onTrial()) {
-			$this->ends_at = $this->trial_ends_at;
-		} else {
-			$this->ends_at = Carbon::createFromTimestamp(
-				$subscription->current_period_end
-			);
-		}
+        // If the user was on trial, we will set the grace period to end when the trial
+        // would have ended. Otherwise, we'll retrieve the end of the billing period
+        // period and make that the end of the grace period for this current user.
+        if ($this->onTrial()) {
+            $this->ends_at = $this->trial_ends_at;
+        } else {
+            $this->ends_at = Carbon::createFromTimestamp(
+                $subscription->current_period_end
+            );
+        }
 
-		$this->save();
+        $this->save();
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Cancel the subscription immediately.
-	 *
-	 * @return $this
-	 */
-	public function cancelNow()
-	{
-		$subscription = $this->asStripeSubscription();
+    /**
+     * Cancel the subscription immediately.
+     *
+     * @return $this
+     */
+    public function cancelNow()
+    {
+        $subscription = $this->asStripeSubscription();
 
-		$subscription->cancel();
+        $subscription->cancel();
 
-		$this->markAsCancelled();
+        $this->markAsCancelled();
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Mark the subscription as cancelled.
-	 *
-	 * @return void
-	 */
-	public function markAsCancelled()
-	{
-		$this->fill(['ends_at' => Carbon::now()])->save();
-	}
+    /**
+     * Mark the subscription as cancelled.
+     *
+     * @return void
+     */
+    public function markAsCancelled()
+    {
+        $this->fill(['ends_at' => Carbon::now()])->save();
+    }
 
-	/**
-	 * Resume the cancelled subscription.
-	 *
-	 * @return $this
-	 *
-	 * @throws \LogicException
-	 */
-	public function resume()
-	{
-		if (!$this->onGracePeriod()) {
-			throw new LogicException('Unable to resume subscription that is not within grace period.');
-		}
+    /**
+     * Resume the cancelled subscription.
+     *
+     * @return $this
+     *
+     * @throws \LogicException
+     */
+    public function resume()
+    {
+        if (! $this->onGracePeriod()) {
+            throw new LogicException('Unable to resume subscription that is not within grace period.');
+        }
 
-		$subscription = $this->asStripeSubscription();
+        $subscription = $this->asStripeSubscription();
 
-		// To resume the subscription we need to set the plan parameter on the Stripe
-		// subscription object. This will force Stripe to resume this subscription
-		// where we left off. Then, we'll set the proper trial ending timestamp.
-		$subscription->plan = $this->stripe_plan;
+        // To resume the subscription we need to set the plan parameter on the Stripe
+        // subscription object. This will force Stripe to resume this subscription
+        // where we left off. Then, we'll set the proper trial ending timestamp.
+        $subscription->plan = $this->stripe_plan;
 
-		if ($this->onTrial()) {
-			$subscription->trial_end = $this->trial_ends_at->getTimestamp();
-		} else {
-			$subscription->trial_end = 'now';
-		}
+        if ($this->onTrial()) {
+            $subscription->trial_end = $this->trial_ends_at->getTimestamp();
+        } else {
+            $subscription->trial_end = 'now';
+        }
 
-		$subscription->save();
+        $subscription->save();
 
-		// Finally, we will remove the ending timestamp from the user's record in the
-		// local database to indicate that the subscription is active again and is
-		// no longer "cancelled". Then we will save this record in the database.
-		$this->fill(['ends_at' => null])->save();
+        // Finally, we will remove the ending timestamp from the user's record in the
+        // local database to indicate that the subscription is active again and is
+        // no longer "cancelled". Then we will save this record in the database.
+        $this->fill(['ends_at' => null])->save();
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Get the subscription as a Stripe subscription object.
-	 *
-	 * @return \Stripe\Subscription
-	 */
-	public function asStripeSubscription()
-	{
-		return $this->user->asStripeCustomer()->subscriptions->retrieve($this->stripe_id);
-	}
+    /**
+     * Get the subscription as a Stripe subscription object.
+     *
+     * @return \Stripe\Subscription
+     */
+    public function asStripeSubscription()
+    {
+        return $this->user->asStripeCustomer()->subscriptions->retrieve($this->stripe_id);
+    }
 }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -42,7 +42,7 @@ class Subscription extends Model
     protected $billingCycleAnchor = null;
 
     /**
-	 * Get the user that owns the subscription (Backwards compatibility)
+     * Get the user that owns the subscription (Backwards compatibility).
      */
     public function user()
     {
@@ -50,7 +50,7 @@ class Subscription extends Model
     }
 
     /**
-     * Get the model related to the subscription
+     * Get the model related to the subscription.
      */
     public function owner()
     {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier;
 use Carbon\Carbon;
 use LogicException;
 use DateTimeInterface;
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 
 class Subscription extends Model
@@ -42,13 +43,24 @@ class Subscription extends Model
 
     /**
      * Get the user that owns the subscription.
+     * (Backwards compatibility)
      */
     public function user()
     {
-        $model = getenv('STRIPE_MODEL') ?: config('services.stripe.model', 'User');
-
-        return $this->belongsTo($model, 'user_id');
+        return $this->owner();
     }
+
+    /**
+     * Get the model related to the subscription
+     */
+    public function owner()
+    {
+        $model = getenv('STRIPE_MODEL') ?: config('services.stripe.model', 'User');
+        $foreignKey = Str::snake(class_basename($model)).'_id';
+
+        return $this->belongsTo($model, $foreignKey);
+    }
+        
 
     /**
      * Determine if the subscription is active, on trial, or within its grace period.

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -55,9 +55,9 @@ class Subscription extends Model
     public function owner()
     {
         $model = getenv('STRIPE_MODEL') ?: config('services.stripe.model', 'User');
-        $foreignKey = Str::snake(class_basename($model)).'_id';
+        $model = new $model;
 
-        return $this->belongsTo($model, $foreignKey);
+        return $this->belongsTo(get_class($model), $model->getForeignKey());
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -10,350 +10,351 @@ use Illuminate\Database\Eloquent\Model;
 
 class Subscription extends Model
 {
-    /**
-     * The attributes that aren't mass assignable.
-     *
-     * @var array
-     */
-    protected $guarded = [];
+	/**
+	 * The attributes that aren't mass assignable.
+	 *
+	 * @var array
+	 */
+	protected $guarded = [];
 
-    /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = [
-        'trial_ends_at', 'ends_at',
-        'created_at', 'updated_at',
-    ];
+	/**
+	 * The attributes that should be mutated to dates.
+	 *
+	 * @var array
+	 */
+	protected $dates = [
+		'trial_ends_at',
+		'ends_at',
+		'created_at',
+		'updated_at',
+	];
 
-    /**
-     * Indicates if the plan change should be prorated.
-     *
-     * @var bool
-     */
-    protected $prorate = true;
+	/**
+	 * Indicates if the plan change should be prorated.
+	 *
+	 * @var bool
+	 */
+	protected $prorate = true;
 
-    /**
-     * The date on which the billing cycle should be anchored.
-     *
-     * @var string|null
-     */
-    protected $billingCycleAnchor = null;
+	/**
+	 * The date on which the billing cycle should be anchored.
+	 *
+	 * @var string|null
+	 */
+	protected $billingCycleAnchor = null;
 
-    /**
-     * Get the user that owns the subscription.
-     * (Backwards compatibility)
-     */
-    public function user()
-    {
-        return $this->owner();
-    }
+	/**
+	 * Get the user that owns the subscription.
+	 * (Backwards compatibility)
+	 */
+	public function user()
+	{
+		return $this->owner();
+	}
 
-    /**
-     * Get the model related to the subscription
-     */
-    public function owner()
-    {
-        $model = getenv('STRIPE_MODEL') ?: config('services.stripe.model', 'User');
-        $foreignKey = Str::snake(class_basename($model)).'_id';
+	/**
+	 * Get the model related to the subscription
+	 */
+	public function owner()
+	{
+		$model = getenv('STRIPE_MODEL') ?: config('services.stripe.model', 'User');
+		$foreignKey = Str::snake(class_basename($model)) . '_id';
 
-        return $this->belongsTo($model, $foreignKey);
-    }
-        
+		return $this->belongsTo($model, $foreignKey);
+	}
 
-    /**
-     * Determine if the subscription is active, on trial, or within its grace period.
-     *
-     * @return bool
-     */
-    public function valid()
-    {
-        return $this->active() || $this->onTrial() || $this->onGracePeriod();
-    }
+	/**
+	 * Determine if the subscription is active, on trial, or within its grace period.
+	 *
+	 * @return bool
+	 */
+	public function valid()
+	{
+		return $this->active() || $this->onTrial() || $this->onGracePeriod();
+	}
 
-    /**
-     * Determine if the subscription is active.
-     *
-     * @return bool
-     */
-    public function active()
-    {
-        return is_null($this->ends_at) || $this->onGracePeriod();
-    }
+	/**
+	 * Determine if the subscription is active.
+	 *
+	 * @return bool
+	 */
+	public function active()
+	{
+		return is_null($this->ends_at) || $this->onGracePeriod();
+	}
 
-    /**
-     * Determine if the subscription is no longer active.
-     *
-     * @return bool
-     */
-    public function cancelled()
-    {
-        return ! is_null($this->ends_at);
-    }
+	/**
+	 * Determine if the subscription is no longer active.
+	 *
+	 * @return bool
+	 */
+	public function cancelled()
+	{
+		return !is_null($this->ends_at);
+	}
 
-    /**
-     * Determine if the subscription is within its trial period.
-     *
-     * @return bool
-     */
-    public function onTrial()
-    {
-        if (! is_null($this->trial_ends_at)) {
-            return Carbon::today()->lt($this->trial_ends_at);
-        } else {
-            return false;
-        }
-    }
+	/**
+	 * Determine if the subscription is within its trial period.
+	 *
+	 * @return bool
+	 */
+	public function onTrial()
+	{
+		if (!is_null($this->trial_ends_at)) {
+			return Carbon::today()->lt($this->trial_ends_at);
+		} else {
+			return false;
+		}
+	}
 
-    /**
-     * Determine if the subscription is within its grace period after cancellation.
-     *
-     * @return bool
-     */
-    public function onGracePeriod()
-    {
-        if (! is_null($endsAt = $this->ends_at)) {
-            return Carbon::now()->lt(Carbon::instance($endsAt));
-        } else {
-            return false;
-        }
-    }
+	/**
+	 * Determine if the subscription is within its grace period after cancellation.
+	 *
+	 * @return bool
+	 */
+	public function onGracePeriod()
+	{
+		if (!is_null($endsAt = $this->ends_at)) {
+			return Carbon::now()->lt(Carbon::instance($endsAt));
+		} else {
+			return false;
+		}
+	}
 
-    /**
-     * Increment the quantity of the subscription.
-     *
-     * @param  int  $count
-     * @return $this
-     */
-    public function incrementQuantity($count = 1)
-    {
-        $this->updateQuantity($this->quantity + $count);
+	/**
+	 * Increment the quantity of the subscription.
+	 *
+	 * @param  int $count
+	 * @return $this
+	 */
+	public function incrementQuantity($count = 1)
+	{
+		$this->updateQuantity($this->quantity + $count);
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     *  Increment the quantity of the subscription, and invoice immediately.
-     *
-     * @param  int  $count
-     * @return $this
-     */
-    public function incrementAndInvoice($count = 1)
-    {
-        $this->incrementQuantity($count);
+	/**
+	 *  Increment the quantity of the subscription, and invoice immediately.
+	 *
+	 * @param  int $count
+	 * @return $this
+	 */
+	public function incrementAndInvoice($count = 1)
+	{
+		$this->incrementQuantity($count);
 
-        $this->user->invoice();
+		$this->user->invoice();
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Decrement the quantity of the subscription.
-     *
-     * @param  int  $count
-     * @return $this
-     */
-    public function decrementQuantity($count = 1)
-    {
-        $this->updateQuantity(max(1, $this->quantity - $count));
+	/**
+	 * Decrement the quantity of the subscription.
+	 *
+	 * @param  int $count
+	 * @return $this
+	 */
+	public function decrementQuantity($count = 1)
+	{
+		$this->updateQuantity(max(1, $this->quantity - $count));
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Update the quantity of the subscription.
-     *
-     * @param  int  $quantity
-     * @param  \Stripe\Customer|null  $customer
-     * @return $this
-     */
-    public function updateQuantity($quantity, $customer = null)
-    {
-        $subscription = $this->asStripeSubscription();
+	/**
+	 * Update the quantity of the subscription.
+	 *
+	 * @param  int $quantity
+	 * @param  \Stripe\Customer|null $customer
+	 * @return $this
+	 */
+	public function updateQuantity($quantity, $customer = null)
+	{
+		$subscription = $this->asStripeSubscription();
 
-        $subscription->quantity = $quantity;
+		$subscription->quantity = $quantity;
 
-        $subscription->save();
+		$subscription->save();
 
-        $this->quantity = $quantity;
+		$this->quantity = $quantity;
 
-        $this->save();
+		$this->save();
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Indicate that the plan change should not be prorated.
-     *
-     * @return $this
-     */
-    public function noProrate()
-    {
-        $this->prorate = false;
+	/**
+	 * Indicate that the plan change should not be prorated.
+	 *
+	 * @return $this
+	 */
+	public function noProrate()
+	{
+		$this->prorate = false;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Change the billing cycle anchor on a plan change.
-     *
-     * @param  int|string  $date
-     * @return $this
-     */
-    public function anchorBillingCycleOn($date = 'now')
-    {
-        if ($date instanceof DateTimeInterface) {
-            $date = $date->getTimestamp();
-        }
+	/**
+	 * Change the billing cycle anchor on a plan change.
+	 *
+	 * @param  int|string $date
+	 * @return $this
+	 */
+	public function anchorBillingCycleOn($date = 'now')
+	{
+		if ($date instanceof DateTimeInterface) {
+			$date = $date->getTimestamp();
+		}
 
-        $this->billingCycleAnchor = $date;
+		$this->billingCycleAnchor = $date;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Swap the subscription to a new Stripe plan.
-     *
-     * @param  string  $plan
-     * @return $this
-     */
-    public function swap($plan)
-    {
-        $subscription = $this->asStripeSubscription();
+	/**
+	 * Swap the subscription to a new Stripe plan.
+	 *
+	 * @param  string $plan
+	 * @return $this
+	 */
+	public function swap($plan)
+	{
+		$subscription = $this->asStripeSubscription();
 
-        $subscription->plan = $plan;
+		$subscription->plan = $plan;
 
-        $subscription->prorate = $this->prorate;
+		$subscription->prorate = $this->prorate;
 
-        if (! is_null($this->billingCycleAnchor)) {
-            $subscription->billingCycleAnchor = $this->billingCycleAnchor;
-        }
+		if (!is_null($this->billingCycleAnchor)) {
+			$subscription->billingCycleAnchor = $this->billingCycleAnchor;
+		}
 
-        // If no specific trial end date has been set, the default behavior should be
-        // to maintain the current trial state, whether that is "active" or to run
-        // the swap out with the exact number of days left on this current plan.
-        if ($this->onTrial()) {
-            $subscription->trial_end = $this->trial_ends_at->getTimestamp();
-        } else {
-            $subscription->trial_end = 'now';
-        }
+		// If no specific trial end date has been set, the default behavior should be
+		// to maintain the current trial state, whether that is "active" or to run
+		// the swap out with the exact number of days left on this current plan.
+		if ($this->onTrial()) {
+			$subscription->trial_end = $this->trial_ends_at->getTimestamp();
+		} else {
+			$subscription->trial_end = 'now';
+		}
 
-        // Again, if no explicit quantity was set, the default behaviors should be to
-        // maintain the current quantity onto the new plan. This is a sensible one
-        // that should be the expected behavior for most developers with Stripe.
-        if ($this->quantity) {
-            $subscription->quantity = $this->quantity;
-        }
+		// Again, if no explicit quantity was set, the default behaviors should be to
+		// maintain the current quantity onto the new plan. This is a sensible one
+		// that should be the expected behavior for most developers with Stripe.
+		if ($this->quantity) {
+			$subscription->quantity = $this->quantity;
+		}
 
-        $subscription->save();
+		$subscription->save();
 
-        $this->user->invoice();
+		$this->user->invoice();
 
-        $this->fill([
-            'stripe_plan' => $plan,
-            'ends_at' => null,
-        ])->save();
+		$this->fill([
+			'stripe_plan' => $plan,
+			'ends_at' => null,
+		])->save();
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Cancel the subscription at the end of the billing period.
-     *
-     * @return $this
-     */
-    public function cancel()
-    {
-        $subscription = $this->asStripeSubscription();
+	/**
+	 * Cancel the subscription at the end of the billing period.
+	 *
+	 * @return $this
+	 */
+	public function cancel()
+	{
+		$subscription = $this->asStripeSubscription();
 
-        $subscription->cancel(['at_period_end' => true]);
+		$subscription->cancel(['at_period_end' => true]);
 
-        // If the user was on trial, we will set the grace period to end when the trial
-        // would have ended. Otherwise, we'll retrieve the end of the billing period
-        // period and make that the end of the grace period for this current user.
-        if ($this->onTrial()) {
-            $this->ends_at = $this->trial_ends_at;
-        } else {
-            $this->ends_at = Carbon::createFromTimestamp(
-                $subscription->current_period_end
-            );
-        }
+		// If the user was on trial, we will set the grace period to end when the trial
+		// would have ended. Otherwise, we'll retrieve the end of the billing period
+		// period and make that the end of the grace period for this current user.
+		if ($this->onTrial()) {
+			$this->ends_at = $this->trial_ends_at;
+		} else {
+			$this->ends_at = Carbon::createFromTimestamp(
+				$subscription->current_period_end
+			);
+		}
 
-        $this->save();
+		$this->save();
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Cancel the subscription immediately.
-     *
-     * @return $this
-     */
-    public function cancelNow()
-    {
-        $subscription = $this->asStripeSubscription();
+	/**
+	 * Cancel the subscription immediately.
+	 *
+	 * @return $this
+	 */
+	public function cancelNow()
+	{
+		$subscription = $this->asStripeSubscription();
 
-        $subscription->cancel();
+		$subscription->cancel();
 
-        $this->markAsCancelled();
+		$this->markAsCancelled();
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Mark the subscription as cancelled.
-     *
-     * @return void
-     */
-    public function markAsCancelled()
-    {
-        $this->fill(['ends_at' => Carbon::now()])->save();
-    }
+	/**
+	 * Mark the subscription as cancelled.
+	 *
+	 * @return void
+	 */
+	public function markAsCancelled()
+	{
+		$this->fill(['ends_at' => Carbon::now()])->save();
+	}
 
-    /**
-     * Resume the cancelled subscription.
-     *
-     * @return $this
-     *
-     * @throws \LogicException
-     */
-    public function resume()
-    {
-        if (! $this->onGracePeriod()) {
-            throw new LogicException('Unable to resume subscription that is not within grace period.');
-        }
+	/**
+	 * Resume the cancelled subscription.
+	 *
+	 * @return $this
+	 *
+	 * @throws \LogicException
+	 */
+	public function resume()
+	{
+		if (!$this->onGracePeriod()) {
+			throw new LogicException('Unable to resume subscription that is not within grace period.');
+		}
 
-        $subscription = $this->asStripeSubscription();
+		$subscription = $this->asStripeSubscription();
 
-        // To resume the subscription we need to set the plan parameter on the Stripe
-        // subscription object. This will force Stripe to resume this subscription
-        // where we left off. Then, we'll set the proper trial ending timestamp.
-        $subscription->plan = $this->stripe_plan;
+		// To resume the subscription we need to set the plan parameter on the Stripe
+		// subscription object. This will force Stripe to resume this subscription
+		// where we left off. Then, we'll set the proper trial ending timestamp.
+		$subscription->plan = $this->stripe_plan;
 
-        if ($this->onTrial()) {
-            $subscription->trial_end = $this->trial_ends_at->getTimestamp();
-        } else {
-            $subscription->trial_end = 'now';
-        }
+		if ($this->onTrial()) {
+			$subscription->trial_end = $this->trial_ends_at->getTimestamp();
+		} else {
+			$subscription->trial_end = 'now';
+		}
 
-        $subscription->save();
+		$subscription->save();
 
-        // Finally, we will remove the ending timestamp from the user's record in the
-        // local database to indicate that the subscription is active again and is
-        // no longer "cancelled". Then we will save this record in the database.
-        $this->fill(['ends_at' => null])->save();
+		// Finally, we will remove the ending timestamp from the user's record in the
+		// local database to indicate that the subscription is active again and is
+		// no longer "cancelled". Then we will save this record in the database.
+		$this->fill(['ends_at' => null])->save();
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Get the subscription as a Stripe subscription object.
-     *
-     * @return \Stripe\Subscription
-     */
-    public function asStripeSubscription()
-    {
-        return $this->user->asStripeCustomer()->subscriptions->retrieve($this->stripe_id);
-    }
+	/**
+	 * Get the subscription as a Stripe subscription object.
+	 *
+	 * @return \Stripe\Subscription
+	 */
+	public function asStripeSubscription()
+	{
+		return $this->user->asStripeCustomer()->subscriptions->retrieve($this->stripe_id);
+	}
 }

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -7,11 +7,11 @@ use Carbon\Carbon;
 class SubscriptionBuilder
 {
     /**
-     * The user model that is subscribing.
+     * The model that is subscribing.
      *
      * @var \Illuminate\Database\Eloquent\Model
      */
-    protected $user;
+    protected $owner;
 
     /**
      * The name of the subscription.
@@ -70,9 +70,9 @@ class SubscriptionBuilder
      * @param  string  $plan
      * @return void
      */
-    public function __construct($user, $name, $plan)
+    public function __construct($owner, $name, $plan)
     {
-        $this->user = $user;
+        $this->owner = $owner;
         $this->name = $name;
         $this->plan = $plan;
     }
@@ -142,7 +142,7 @@ class SubscriptionBuilder
     }
 
     /**
-     * Add a new Stripe subscription to the user.
+     * Add a new Stripe subscription to the Stripe model.
      *
      * @param  array  $options
      * @return \Laravel\Cashier\Subscription
@@ -171,7 +171,7 @@ class SubscriptionBuilder
             $trialEndsAt = $this->trialDays ? Carbon::now()->addDays($this->trialDays) : null;
         }
 
-        return $this->user->subscriptions()->create([
+        return $this->owner->subscriptions()->create([
             'name' => $this->name,
             'stripe_id' => $subscription->id,
             'stripe_plan' => $this->plan,
@@ -190,15 +190,15 @@ class SubscriptionBuilder
      */
     protected function getStripeCustomer($token = null, array $options = [])
     {
-        if (! $this->user->stripe_id) {
-            $customer = $this->user->createAsStripeCustomer(
+        if (! $this->owner->stripe_id) {
+            $customer = $this->owner->createAsStripeCustomer(
                 $token, array_merge($options, array_filter(['coupon' => $this->coupon]))
             );
         } else {
-            $customer = $this->user->asStripeCustomer();
+            $customer = $this->owner->asStripeCustomer();
 
             if ($token) {
-                $this->user->updateCard($token);
+                $this->owner->updateCard($token);
             }
         }
 
@@ -245,7 +245,7 @@ class SubscriptionBuilder
      */
     protected function getTaxPercentageForPayload()
     {
-        if ($taxPercentage = $this->user->taxPercentage()) {
+        if ($taxPercentage = $this->owner->taxPercentage()) {
             return $taxPercentage;
         }
     }


### PR DESCRIPTION
This is a pull request related to proposal #334 

I know that guidelines dictate that a proposal needs to be approved, but I think this PR will better explain the goal of the proposal.

One of the main changes other than the dynamic loading of the correct model and foreign key based on the configuration, I renamed a variable related to the model from `user` to `owner` (in lack of a better word).

For backward compatibility, the `Subscription::user` method remains, but utilizes `Subscription::owner`.

Also, updated the README to better match test setup conditions.