### PR TITLE
Set Subscription Prorate Argument when using updateQuantity

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -161,6 +161,8 @@ class Subscription extends Model
         $subscription = $this->asStripeSubscription();
 
         $subscription->quantity = $quantity;
+        
+        $subscription->prorate = $this->prorate;
 
         $subscription->save();
 


### PR DESCRIPTION
Currently
`$subscription->noProrate()->updateQuantity($amount);` does not correctly set the prorate argument on the Stripe API when updating the subscription.

The proposed change automatically sets the `prorate` property that's on the Subscription model.