### PR TITLE
Fix coupon being double applied

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -191,9 +191,7 @@ class SubscriptionBuilder
     protected function getStripeCustomer($token = null, array $options = [])
     {
         if (! $this->owner->stripe_id) {
-            $customer = $this->owner->createAsStripeCustomer(
-                $token, array_merge($options, array_filter(['coupon' => $this->coupon]))
-            );
+            $customer = $this->owner->createAsStripeCustomer($token, $options);
         } else {
             $customer = $this->owner->asStripeCustomer();
 


### PR DESCRIPTION
Remove coupon attachment to customer when creating a new customer as part of the subscription creation process. Currently, if a new subscription is created for a user who is not already registered with Stripe, then the coupon is applied to both the customer entity AND the subscription. This results in the coupon being applied to payments multiple times. If attaching a coupon to the customer entity is required, the Stripe customer may first be created explicitly calling (Billable model)->createAsStripeCustomer($token, $options), where 'coupon' is set as one of the options .