### PR TITLE
Fix Skipping trial on swapping

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -171,7 +171,7 @@ class Subscription extends Model
         $subscription = $this->asStripeSubscription();
 
         $subscription->quantity = $quantity;
-        
+
         $subscription->prorate = $this->prorate;
 
         $subscription->save();
@@ -208,6 +208,18 @@ class Subscription extends Model
         }
 
         $this->billingCycleAnchor = $date;
+
+        return $this;
+    }
+
+    /**
+     * Force the trial to end immediately.
+     *
+     * @return $this
+     */
+    public function skipTrial()
+    {
+        $this->trial_ends_at = null;
 
         return $this;
     }


### PR DESCRIPTION
As per the docs https://laravel.com/docs/5.3/billing#changing-plans

> If you would like to swap plans and cancel any trial period the user is currently on, you may use the  skipTrial method:

```
$user->subscription('main')
        ->skipTrial()
        ->swap('provider-plan-id');
```

However the Subscription model doesn't have a `skipTrial()` method, this PR adds the proper method.