### PR TITLE
Specify trial duration of a subscription with DateTime

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -35,13 +35,6 @@ class SubscriptionBuilder
     protected $quantity = 1;
 
     /**
-     * The number of trial days to apply to the subscription.
-     *
-     * @var int|null
-     */
-    protected $trialDays;
-
-    /**
      * Indicates that the trial should end immediately.
      *
      * @var bool
@@ -61,6 +54,11 @@ class SubscriptionBuilder
      * @var array|null
      */
     protected $metadata;
+
+    /**
+     * @var Carbon
+     */
+    protected $trialExpires;
 
     /**
      * Create a new subscription builder instance.
@@ -91,14 +89,27 @@ class SubscriptionBuilder
     }
 
     /**
-     * Specify the ending date of the trial.
+     * Specify the number of days of the trial.
      *
      * @param  int  $trialDays
      * @return $this
      */
     public function trialDays($trialDays)
     {
-        $this->trialDays = $trialDays;
+        $this->trialExpires = Carbon::now()->addDays($trialDays);
+
+        return $this;
+    }
+
+    /**
+     * Specify the ending date of the trial.
+     *
+     * @param Carbon $trialUntil
+     * @return $this
+     */
+    public function trialUntil(Carbon $trialUntil)
+    {
+        $this->trialExpires = $trialUntil;
 
         return $this;
     }
@@ -168,7 +179,7 @@ class SubscriptionBuilder
         if ($this->skipTrial) {
             $trialEndsAt = null;
         } else {
-            $trialEndsAt = $this->trialDays ? Carbon::now()->addDays($this->trialDays) : null;
+            $trialEndsAt = $this->trialExpires;
         }
 
         return $this->owner->subscriptions()->create([
@@ -233,8 +244,8 @@ class SubscriptionBuilder
             return 'now';
         }
 
-        if ($this->trialDays) {
-            return Carbon::now()->addDays($this->trialDays)->getTimestamp();
+        if ($this->trialExpires) {
+            return $this->trialExpires->getTimestamp();
         }
     }
 


### PR DESCRIPTION
Allows you to explicitly define when a trial will end. 

https://github.com/laravel/cashier/issues/345
