### PR TITLE
#397 Handling multiplan subscriptions at Stripe

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -187,8 +187,17 @@ trait Billable
             return $subscription->valid();
         }
 
-        return $subscription->valid() &&
-               $subscription->stripe_plan === $plan;
+        if ($subscription->valid() && $subscription->stripe_plan === $plan) {
+            return true;
+        }
+
+        $plan = $this->subscriptionItem($plan);
+
+        if (!is_null($plan) && $subscription->valid()) {
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -492,6 +501,9 @@ trait Billable
             if ($subscription->stripe_plan === $plan) {
                 return true;
             }
+            if ($subscription->hasItem($plan)) {
+                return true;
+            }
         }
 
         return false;
@@ -505,9 +517,13 @@ trait Billable
      */
     public function onPlan($plan)
     {
-        return ! is_null($this->subscriptions->first(function ($value) use ($plan) {
-            return $value->stripe_plan === $plan && $value->valid();
-        }));
+        $subscription = $this->subscriptionByPlan($plan);
+
+        if (!is_null($subscription)) {
+            return $subscription->valid();
+        }
+
+        return false;
     }
 
     /**
@@ -610,5 +626,96 @@ trait Billable
     public static function setStripeKey($key)
     {
         static::$stripeKey = $key;
+    }
+
+    /**
+     * Begin creating a new multisubscription.
+     *
+     * @param  string  $subscription
+     * @param  string  $plan
+     * @return \Laravel\Cashier\SubscriptionBuilder
+     */
+    public function newMultisubscription()
+    {
+        return new MultisubscriptionBuilder($this);
+    }
+
+    /**
+     * Get all the subscription items for the user
+     */
+    public function subscriptionItems()
+    {
+        return $this->hasManyThrough(SubscriptionItem::class, Subscription::class)->orderBy('created_at', 'desc');
+    }
+
+    /**
+     * Gets a subscription item instance by name.
+     *
+     * @param  string  $plan
+     * @return \Laravel\Cashier\SubscriptionItem|null
+     */
+    public function subscriptionItem($plan)
+    {
+        $itemsTable = (new SubscriptionItem)->getTable();
+        return $this->subscriptionItems()->where($itemsTable.'.stripe_plan', $plan)->orderBy($itemsTable.'.created_at', 'desc')->first();
+    }
+
+    /**
+     * Adds a plan to the model's subscription
+     *
+     * @param string $plan The plan's ID
+     * @param integer $quantity The plan's quantity
+     * @param string $subscription The subscription's name
+     * @return \Laravel\Cashier\Subscription
+     */
+    public function addPlan($plan, $prorate = true, $quantity = 1, $subscription = 'default')
+    {
+        $subscription = $this->subscription($subscription);
+
+        if (!is_null($subscription)) {
+            return $subscription->addItem($plan, $prorate, $quantity);
+        }
+
+        return $this->newMultisubscription($subscription)->addPlan($plan, $prorate, $quantity)->create();
+    }
+
+    /**
+     * Removes a plan from the model's subscription
+     *
+     * @param string $plan The plan's ID
+     * @return \Laravel\Cashier\Subscription|null
+     */
+    public function removePlan($plan, $prorate = true, $subscription = 'default')
+    {
+        $subscription = $this->subscription($subscription);
+
+        if (is_null($subscription)) {
+            return null;
+        }
+
+        return $subscription->removeItem($plan, $prorate);
+    }
+
+    /**
+     * Gets the subscription that contains the given plan
+     *
+     * @param string $plan The plan's ID
+     * @return \Laravel\Cashier\Subscription|null
+     */
+    public function subscriptionByPlan($plan)
+    {
+        $subscription = $this->subscriptions()->where('stripe_plan', $plan)->first();
+
+        if (!is_null($subscription)) {
+            return $subscription;
+        }
+
+        $item = $this->subscriptionItem($plan);
+
+        if (is_null($item)) {
+            return null;
+        }
+
+        return $item->subscription;
     }
 }

--- a/src/MultisubscriptionBuilder.php
+++ b/src/MultisubscriptionBuilder.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Laravel\Cashier;
+
+use Carbon\Carbon;
+
+class MultisubscriptionBuilder extends SubscriptionBuilder
+{
+    /**
+     * The plans being subscribed to.
+     *
+     * @var array
+     */
+    protected $plans = [];
+    
+    /**
+     * Create a new subscription builder instance.
+     *
+     * @param  mixed  $owner
+     * @param  string  $name
+     * @param  string  $plan
+     * @return void
+     */
+    public function __construct($owner, $name = 'default')
+    {
+        $this->owner = $owner;
+        $this->name = $name;
+    }
+    
+    /**
+     * Add a new Stripe subscription to the Stripe model.
+     *
+     * @param  string  $code
+     * @param  int  $quantity
+     */
+    public function addPlan($code, $quantity = 1)
+    {
+        $this->plans[$code] = $quantity;
+        return $this;
+    }
+    
+    /**
+     * Creates a new Stripe subscription with multiple plans.
+     *
+     * @param  string|null  $token
+     * @param  array  $options
+     * @return \Laravel\Cashier\Subscription
+     */
+    public function create($token = null, array $options = [])
+    {
+        $customer = $this->getStripeCustomer($token, $options);
+
+        $stripeSubscription = $customer->subscriptions->create($this->buildPayload());
+
+        if ($this->skipTrial) {
+            $trialEndsAt = null;
+        } else {
+            $trialEndsAt = $this->trialExpires;
+        }
+        
+        // registers the subscription
+        $subscription = $this->owner->subscriptions()->create([
+            'name' => $this->name,
+            'stripe_id' => $stripeSubscription->id,
+            'stripe_plan' => '',
+            'quantity' => 0,
+            'trial_ends_at' => $trialEndsAt,
+            'ends_at' => null,
+        ]);
+        
+        // registers the subscription's items
+        foreach ($stripeSubscription->items->data as $item) {
+            $subscription->subscriptionItems()->create([
+                'stripe_id' => $item['id'],
+                'stripe_plan' => $item['plan']['id'],
+                'quantity' => $item['quantity'],
+            ]);
+        }
+        
+        return $subscription;
+    }
+    
+    /**
+     * Build the payload for subscription creation.
+     *
+     * @return array
+     */
+    protected function buildPayload()
+    {
+        return array_filter([
+            'items' => $this->buildPayloadItems(),
+            'coupon' => $this->coupon,
+            'trial_end' => $this->getTrialEndForPayload(),
+            'tax_percent' => $this->getTaxPercentageForPayload(),
+            'metadata' => $this->metadata,
+        ]);
+    }
+    
+    protected function buildPayloadItems()
+    {
+        $items = [];
+        foreach ($this->plans as $plan => $quantity) {
+            array_push($items,[
+                'plan' => $plan,
+                'quantity' => $quantity,
+            ]);
+        }
+        return $items;
+    }
+}

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -163,10 +163,9 @@ class Subscription extends Model
      * Update the quantity of the subscription.
      *
      * @param  int  $quantity
-     * @param  \Stripe\Customer|null  $customer
      * @return $this
      */
-    public function updateQuantity($quantity, $customer = null)
+    public function updateQuantity($quantity)
     {
         $subscription = $this->asStripeSubscription();
 
@@ -337,6 +336,10 @@ class Subscription extends Model
         if (! $this->onGracePeriod()) {
             throw new LogicException('Unable to resume subscription that is not within grace period.');
         }
+        
+        if (!$this->subscriptionItems->isEmpty()) {
+            throw new LogicException("Cannot update using plan parameter when multiple plans exist on the subscription. Updates must be made to individual items instead.");
+        }
 
         $subscription = $this->asStripeSubscription();
 
@@ -369,5 +372,95 @@ class Subscription extends Model
     public function asStripeSubscription()
     {
         return $this->user->asStripeCustomer()->subscriptions->retrieve($this->stripe_id);
+    }
+    
+    /**
+     * Get the subscription items for the model.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function subscriptionItems()
+    {
+        return $this->hasMany(SubscriptionItem::class, $this->getForeignKey())->orderBy('created_at', 'desc');
+    }
+    
+    /**
+     * Adds a plan to the subscription
+     *
+     * @param string $plan The added plan's ID
+     * @param integer $quantity The quantity to be added
+     * @return $this
+     */
+    public function addItem($plan, $prorate = true, $quantity = 1)
+    {
+        // retrieves the subscription stored at Stripe
+        $stripeSubscription = $this->asStripeSubscription();
+        
+        // adds the new item at Stripe
+        $stripeSubscriptionItem = $stripeSubscription->items->create([
+            'plan' => $plan,
+            'prorate' => $prorate,
+            'quantity' => $quantity,
+        ]);
+        
+        // saves the new item in the database
+        $this->subscriptionItems()->create([
+            'stripe_id' => $stripeSubscriptionItem->id,
+            'stripe_plan' => $plan,
+            'quantity' => $quantity,
+        ]);
+        
+        return $this;
+    }
+    
+    /**
+     * Adds a plan from the subscription
+     *
+     * @param string $plan The removed plan's ID
+     * @return $this
+     */
+    public function removeItem($plan, $prorate = true)
+    {
+        $item = $this->subscriptionItems()->where('stripe_plan', $plan)->first();
+        
+        if (is_null($item)) {
+            // item not found
+            return $this;
+        }
+        
+        // retrieves the item stored at Stripe
+        $stripeItem = $item->asStripeSubscriptionItem();
+        
+        // deletes the item at Stripe
+        $stripeItem->delete([
+            'prorate' => $prorate,
+        ]);
+        
+        // removes the item from the database
+        $this->subscriptionItems()->where('stripe_plan', $plan)->delete();
+        
+        return $this;
+    }
+    
+    /**
+     * Gets the item by name
+     *
+     * @param string $plan The plan's ID
+     * @return Laravel\Cashier\SubscriptionItem|null
+     */
+    public function subscriptionItem($plan)
+    {
+        return $this->subscriptionItems()->where('stripe_plan', $plan)->first();
+    }
+    
+    /**
+     * Determines if the subscription contains the given plan
+     * 
+     * @param string $plan The plan's ID
+     * @return bool
+     */
+    public function hasItem($plan)
+    {
+        return !!$this->subscriptionItem($plan);
     }
 }

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Laravel\Cashier;
+
+use Carbon\Carbon;
+use LogicException;
+use DateTimeInterface;
+use Illuminate\Database\Eloquent\Model;
+
+class SubscriptionItem extends Model
+{
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'created_at', 'updated_at',
+    ];
+    
+    /**
+     * Get the subscription as a Stripe subscription object.
+     *
+     * @return \Stripe\Subscription
+     */
+    public function asStripeSubscriptionItem()
+    {
+        $stripeSubscription = $this->subscription->asStripeSubscription();
+        // strips out the "subscription" parameter which causes an API error (unknown parameter)
+        $stripeSubscription->items->url = substr($stripeSubscription->items->url, 0, strpos($stripeSubscription->items->url, '?'));
+        
+        return $stripeSubscription->items->retrieve($this->stripe_id);
+    }
+    
+    /**
+     * Gets the subscription that contains this item
+     */
+    public function subscription()
+    {
+        return $this->belongsTo(Subscription::class);
+    }
+    
+    /**
+     * Increment the quantity of the subscription.
+     *
+     * @param  int  $count
+     * @param  bool  $prorate
+     * @return $this
+     */
+    public function incrementQuantity($count = 1, $prorate = true)
+    {
+        $this->updateQuantity($this->quantity + $count, $prorate);
+
+        return $this;
+    }
+
+    /**
+     *  Increment the quantity of the subscription, and invoice immediately.
+     *
+     * @param  int  $count
+     * @param  bool  $prorate
+     * @return $this
+     */
+    public function incrementAndInvoice($count = 1, $prorate = true)
+    {
+        $this->incrementQuantity($count, $prorate);
+
+        $this->subscription->user->invoice();
+
+        return $this;
+    }
+
+    /**
+     * Decrement the quantity of the subscription.
+     *
+     * @param  int  $count
+     * @param  bool  $prorate
+     * @return $this
+     */
+    public function decrementQuantity($count = 1, $prorate = true)
+    {
+        $this->updateQuantity(max(1, $this->quantity - $count), $prorate);
+
+        return $this;
+    }
+
+    /**
+     * Update the quantity of the subscription.
+     *
+     * @param  int  $quantity
+     * @param  bool  $prorate
+     * @return $this
+     */
+    public function updateQuantity($quantity, $prorate = true)
+    {
+        $subscriptionItem = $this->asStripeSubscriptionItem();
+
+        $subscriptionItem->quantity = $quantity;
+
+        $subscriptionItem->prorate = $prorate;
+
+        $subscriptionItem->save();
+
+        $this->quantity = $quantity;
+
+        $this->save();
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Stripe handles multiple plans included in one subscription (they are subscription items).
This is useful because this way the customer will see only one debit on their bank account for every billing cycle instead of seeing one for every subscribed plan. Eg. if your customer is subscribed to a main service plus 4 features, they will get 5 debits every month. This is bad for service providers because (a) it is ugly (b) it is more expensive due to the fix fees.
For more details, cf. https://stripe.com/docs/subscriptions/multiplan

Implementation ideas:

- Similarly to the Subscription class, the SubscriptionItem class should be created to handle the plans included in the subscription.

- The MultisubscriptionBuilder class, extending the SubscriptionBuilder class, should be created to handle the creation process including multiple plans.

- New methods should be added to the Billable trait and to the Subscription class to check if the user is on a given plan when it is included in a multiplan subscription.

- The unit test should be appended to handle the new scenarios.