### PR TITLE
Stripe Trial End Date

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -98,7 +98,7 @@ class SubscriptionBuilder
      */
     public function trialDays($trialDays)
     {
-        $this->trialExpires = Carbon::now()->addDays($trialDays);
+        $this->setTrialExpires(Carbon::now()->addDays($trialDays))
 
         return $this;
     }
@@ -111,8 +111,8 @@ class SubscriptionBuilder
      */
     public function trialUntil(Carbon $trialUntil)
     {
-        $this->trialExpires = $trialUntil;
-
+        $this->setTrialExpires($trialUntil);
+        
         return $this;
     }
 
@@ -258,6 +258,21 @@ class SubscriptionBuilder
     {
         if ($taxPercentage = $this->owner->taxPercentage()) {
             return $taxPercentage;
+        }
+    }
+    
+    /**
+     * Sets the date/time the trial will expire and ensures it is in the future.
+     *
+     * @param  Carbon\Carbon  $trialEnd
+     * @return null
+     */
+    protected function setTrialExpires(Carbon $trialEnd)
+    {
+        if ($trialEnd->isFuture()) {
+            $this->trialExpires = $trialEnd;
+        } else {
+            $this->trialExpires = null;
         }
     }
 }

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -98,7 +98,7 @@ class SubscriptionBuilder
      */
     public function trialDays($trialDays)
     {
-        $this->setTrialExpires(Carbon::now()->addDays($trialDays))
+        $this->setTrialExpires(Carbon::now()->addDays($trialDays));
 
         return $this;
     }


### PR DESCRIPTION
The Stripe API will return an error if the trial end date is not in the future, for instance if you did:
```
$subscription->trialDays(0)->create();
//or
$subscription->trialUntil(Carbon::create(2010, 1, 31, 0))->create();
```
I added the function "setTrialExpires" which only sets $trialExpires if its a date in the future.