### PR TITLE
Handle exception, if stripe customer has no any subscriptions

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -367,9 +367,16 @@ class Subscription extends Model
      * Get the subscription as a Stripe subscription object.
      *
      * @return \Stripe\Subscription
+     *
+     * @throws \LogicException
      */
     public function asStripeSubscription()
     {
-        return $this->user->asStripeCustomer()->subscriptions->retrieve($this->stripe_id);
+        $subscriptions = $this->user->asStripeCustomer()->subscriptions;
+        if (! $subscriptions) {
+            throw new LogicException('Unable to retrieve subscription. Stripe customer has no any subscriptions');
+        }
+
+        return $subscriptions->retrieve($this->stripe_id);
     }
 }


### PR DESCRIPTION
got this when tried to swap plan
`Call to a member function retrieve() on null in /cashier/src/Subscription.php:374`
So, think it is better to handle case, if Stripe customer has no any subscriptions