### PR TITLE
Correct trial

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -100,7 +100,7 @@ class Subscription extends Model
     public function onTrial()
     {
         if (! is_null($this->trial_ends_at)) {
-            return Carbon::today()->lt($this->trial_ends_at);
+            return Carbon::now()->lt($this->trial_ends_at);
         } else {
             return false;
         }


### PR DESCRIPTION
`today` method causes wrong behaviour. If subscription was paid and turned into active, user can't change subscription via `swap` method till the end of day - it causes transmitting `trial_end` from past time. So client gets a message "Invalid timestamp: must be an integer Unix timestamp in the future." out of API call.