### PR TITLE
Allow the vendor VAT to be supplied, as required by EU regulations

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -90,6 +90,9 @@
                 @if (isset($phone))
                     <strong>T</strong> {{ $phone }}<br>
                 @endif
+                @if (isset($vendorVat))
+                    {{ $vendorVat }}<br>
+                @endif
                 @if (isset($url))
                     <a href="{{ $url }}">{{ $url }}</a>
                 @endif


### PR DESCRIPTION
In theory, we could use the existing `$vat` variable, but that's being used/overwritten in `Spark` to supply the information from the client, not the vendor.

This would allow a user to supply a `$vendorVat` variable to be added to the vendor information, below the address.

This would also solve issue #441.