### PR TITLE
Add skip trial to delete subscription

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,4 +44,4 @@ Thank you for considering contributing to the Cashier. You can read the contribu
 
 ## License
 
-Laravel Cashier is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT)
+Laravel Cashier is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT).

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ You will need to set the following details locally and on your Stripe account in
 
     STRIPE_KEY=
     STRIPE_SECRET=
-    STRIPE_MODEL=User
+    STRIPE_MODEL=Laravel\Cashier\Tests\Fixtures\User
 
 ### Stripe
 

--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -90,6 +90,9 @@
                 @if (isset($phone))
                     <strong>T</strong> {{ $phone }}<br>
                 @endif
+                @if (isset($vendorVat))
+                    {{ $vendorVat }}<br>
+                @endif
                 @if (isset($url))
                     <a href="{{ $url }}">{{ $url }}</a>
                 @endif

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -100,7 +100,7 @@ class Subscription extends Model
     public function onTrial()
     {
         if (! is_null($this->trial_ends_at)) {
-            return Carbon::today()->lt($this->trial_ends_at);
+            return Carbon::now()->lt($this->trial_ends_at);
         } else {
             return false;
         }


### PR DESCRIPTION
    public function markAsCancelled()
    {
                        
        $this->fill(['ends_at' => Carbon::now()])->save();
    }


change to
     
    public function markAsCancelled()
     {                    
        $this->fill(['ends_at' => Carbon::now()])->save();
        $this->skipTrial();
    }

This need for isSubscriebed method returns true after delete  subscription 