### PR TITLE
Changing plans does not change the local subscription name (#412)

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -232,9 +232,10 @@ class Subscription extends Model
      * Swap the subscription to a new Stripe plan.
      *
      * @param  string  $plan
+     * @param  string  $name
      * @return $this
      */
-    public function swap($plan)
+    public function swap($plan, $name = null)
     {
         $subscription = $this->asStripeSubscription();
 
@@ -266,10 +267,16 @@ class Subscription extends Model
 
         $this->user->invoice();
 
-        $this->fill([
-            'stripe_plan' => $plan,
-            'ends_at' => null,
-        ])->save();
+        $attributes = [
+             'stripe_plan' => $plan,
+             'ends_at' => null,
+        ];
+
+        if ($name) {
+            $attributes['name'] = $name;
+        }
+
+        $this->fill($attributes)->save();
 
         return $this;
     }

--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -122,7 +122,12 @@ class CashierTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $subscription->quantity);
 
         // Swap Plan
-        $subscription->swap('monthly-10-2');
+        $subscription->swap('monthly-10-2', 'premium');
+        $this->assertEquals('premium', $subscription->name);
+
+        // Rename Plan
+        $subscription->swap('monthly-10-2', 'main');
+        $this->assertEquals('main', $subscription->name);
 
         $this->assertEquals('monthly-10-2', $subscription->stripe_plan);
 


### PR DESCRIPTION
This PR fixes an issue as identified at issue #412.

It allows for a simple way to update the subscription name when swapping a plan.

If the PR is accepted, I will submit a separate PR to update the Laravel Cashier documentation.