### PR TITLE
Fix: PDF Options, Allow General PDF Format Configuration

### DIFF
--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -13,6 +13,11 @@ class CashierServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $configPathForPDFs = __DIR__ . '/../config/dompdf.php';
+        if (file_exists($configPathForPDFs)) {
+            $this->mergeConfigFrom($configPathForPDFs, 'dompdf');
+        }
+
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'cashier');
 
         $this->publishes([

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -4,8 +4,10 @@ namespace Laravel\Cashier;
 
 use Carbon\Carbon;
 use Dompdf\Dompdf;
+use Dompdf\Options;
 use Illuminate\Support\Facades\View;
 use Stripe\Invoice as StripeInvoice;
+use Illuminate\Support\Facades\Config;
 use Symfony\Component\HttpFoundation\Response;
 
 class Invoice
@@ -252,11 +254,9 @@ class Invoice
             define('DOMPDF_ENABLE_AUTOLOAD', false);
         }
 
-        if (file_exists($configPath = base_path().'/vendor/dompdf/dompdf/dompdf_config.inc.php')) {
-            require_once $configPath;
-        }
+        $config = new Options(Config::get('dompdf' , null));
 
-        $dompdf = new Dompdf;
+        $dompdf = new Dompdf($config);
 
         $dompdf->loadHtml($this->view($data)->render());
 


### PR DESCRIPTION
The code allowing customisation of the PDF invoices does not match what is available in the version of dompdf required by cashier.  These changes allow users to optionally use Laravel style configuration file that can be shared with any part of the application that uses the `dompdf/dompdf` library to generate PDF files.

**Benefits:**

Developers can set important options like the `paper size` or `orientation` for invoices.  Unknown or unused settings will be discarded if they are not recognised between versions.  This has been a major requirement for projects that leverage Cashier directly or indirectly through `Spark`.

**Usage:**

A developer who wants to change the PDF formatting can create a `dompdf.php` file in thier `config` directory and those options will be passed to the renderer when an invoice is created.

**Example:**

This would be a simple file, `/config/dompdf.php` with default settings.

```php
<?php

return [

    /*
    |--------------------------------------------------------------------------
    | Default Paper Size
    |--------------------------------------------------------------------------
    |
    | This option determines the default paper size for invoices.  Expand your
    | market by billions* by using using 'a4', be bespoke by choosing 'legal'.
    |
    */

    'default_paper_size' => env('DOMPDF_PAPER_SIZE', 'letter'),

    /*
    |--------------------------------------------------------------------------
    | Default Paper Orientation
    |--------------------------------------------------------------------------
    |
    | This option determines the default paper orientation for invoices. Use
    | 'landscape' for something more exotic.
    |
    */

    'default_paper_orientation' => env('DOMPDF_PAPER_SIZE', 'portrait'),

    /*
    |--------------------------------------------------------------------------
    | Default HTML Processor
    |--------------------------------------------------------------------------
    |
    | This option determines the parsing engine for invoices. Why party like
    | it's 1999 when you already have to write a restrictive subset of HTML
    | for email and invoice templates? You know what to do... you savage.
    |
    */

    'enable_html5_parser' => env('DOMPDF_USE_HTML5_PARSER', false),

];
```

**Documentation Updates:**

Detailed PDF formatting options can be set by creating a `dompdf.php` file in the project's `config` directory, specifying the options to be passed to the PDF renderer. See the following for details.
https://github.com/dompdf/dompdf/blob/master/src/Options.php

I'm not good at writing copy.

**Implementation Notes:**

Creating and initialising an `Dompdf\Options` object from an array of values first appears to be a better code path.  While there is an interface for supplying an `Dompdf\Options` object after the `Dompdf\Dompdf` object is created ( _see Dompdf::set_options()_ ), it does not work reliably for all option values.  I may submit another pull request to that project to address this.

I have not added a publishable configuration file because `Laravel/Cashier` could change its dependencies.  I feel it is outside of scope.

Everything I know, I learned from @JeffreyWay
