### PR TITLE
Allow for Subscription model extension

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -20,6 +20,34 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 trait Billable
 {
     /**
+      * The Eloquent subscription model name.
+      *
+      * @var string
+      */
+     protected static $subscriptionModel = Subscription::class;
+ 
+     /**
+      * Set the Subscription Model
+      * - Allows for override in constructor
+      *
+      * @param $model
+      */
+     public function setSubscriptionModel($model)
+     {
+         self::$subscriptionModel = $model;
+     }
+ 
+     /**
+      * Get Subscription Model
+      *
+      * @return string
+      */
+     public function getSubscriptionModel()
+     {
+         return self::$subscriptionModel;
+     }
+    
+    /**
      * The Stripe API key.
      *
      * @var string
@@ -214,7 +242,7 @@ trait Billable
      */
     public function subscriptions()
     {
-        return $this->hasMany(Subscription::class, $this->getForeignKey())->orderBy('created_at', 'desc');
+        return $this->hasMany(self::$subscriptionModel, $this->getForeignKey())->orderBy('created_at', 'desc');
     }
 
     /**


### PR DESCRIPTION
Extracted from https://github.com/laravel/cashier-braintree/pull/35 to just add the getter and setter for the subscription model, allowing it to be overridden in the constructor. (still an open issue in #367 ).

The original pull request on the braintree project seems to only have been declined because of issues around the other part of it (passing $options through updateCard), and the first part is something I'm having to do for my use case (extra relationships on the subscription model), so figured it's probably worth seeing if this would make it in on its own