### PR TITLE
Bug fix for issue mentioned in #370 - Cards not synchronising with table after card deletion.

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -459,6 +459,8 @@ trait Billable
         $this->cards()->each(function ($card) {
             $card->delete();
         });
+        
+        $this->updateCardFromStripe();
     }
 
     /**


### PR DESCRIPTION
Quick bug fix for an issue mentioned in #370 where the user's Stripe card details aren't removed from their model entry on running the `deleteCards()` method.

Fixed by triggering by synchronizing the user's card details with Stripe after card deletion.