### PR TITLE
[8.0] Updated to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=7.0",
         "dompdf/dompdf": "^0.8.0",
         "illuminate/database": "~5.3",
         "illuminate/support": "~5.3",
@@ -27,7 +27,7 @@
         "illuminate/routing": "~5.3",
         "illuminate/view": "~5.3",
         "mockery/mockery": "~1.0",
-        "phpunit/phpunit": "~5.0",
+        "phpunit/phpunit": "~6.0",
         "vlucas/phpdotenv": "~2.0"
     },
     "autoload": {

--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -4,13 +4,13 @@ namespace Laravel\Cashier\Tests;
 
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Laravel\Cashier\Tests\Fixtures\CashierTestControllerStub;
 
-class CashierTest extends PHPUnit_Framework_TestCase
+class CashierTest extends TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/WebhookControllerTest.php
+++ b/tests/WebhookControllerTest.php
@@ -3,10 +3,10 @@
 namespace Laravel\Cashier\Tests;
 
 use Illuminate\Http\Request;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Laravel\Cashier\Tests\Fixtures\WebhookControllerTestStub;
 
-class WebhookControllerTest extends PHPUnit_Framework_TestCase
+class WebhookControllerTest extends TestCase
 {
     public function testProperMethodsAreCalledBasedOnStripeEvent()
     {


### PR DESCRIPTION
Updated `phpunit/phpunit` to `~6.0`.

Dropped support to `PHP 5.6`, as PHPUnit 6.0 [requires PHP 7.0](https://github.com/sebastianbergmann/phpunit/blob/master/composer.json#L25).