### PR TITLE
Test against PHP 7.1 and 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
 
 sudo: false
 


### PR DESCRIPTION
With the release of [`PHP 7.2`](http://php.net/archive/2017.php#id2017-11-30-1), would be nice to test Cashier against it. Also, I've added `PHP 7.1` test.

PS: I won't apply [this StyleCi changes](https://styleci.io/analyses/zEQ6vv). There are not related to this PR :sweat_smile: 