### PR TITLE
Add tax to subtotal

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -120,7 +120,7 @@ class Invoice
      */
     public function discount()
     {
-        return $this->formatAmount($this->invoice->subtotal - $this->invoice->total);
+        return $this->formatAmount($this->invoice->subtotal + $this->invoice->tax - $this->invoice->total);
     }
 
     /**


### PR DESCRIPTION
Tax must be added to subtotal to have a correct discount value:

## Example

**Without the fix:**
Subtotal = **100$**
Coupon = **50$**
Tax = **10$**
Total = **60$**
`function discount()` = **40$** ⚠️ bad result

**With the fix:**
Subtotal = **100$**
Coupon = **50$**
Tax = **10$**
Total = **60$**
`function discount()` = **50$** 👍 good result
