### PR TITLE
[Security] Prevents unauthorized access to Stripe invoices

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -15,6 +15,7 @@ use Stripe\Customer as StripeCustomer;
 use Stripe\BankAccount as StripeBankAccount;
 use Stripe\InvoiceItem as StripeInvoiceItem;
 use Stripe\Error\InvalidRequest as StripeErrorInvalidRequest;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 trait Billable
@@ -282,6 +283,10 @@ trait Billable
             throw new NotFoundHttpException;
         }
 
+        if ($invoice->customer !== $this->stripe_id) {
+            throw new AccessDeniedHttpException;
+        }
+
         return $invoice;
     }
 
@@ -468,7 +473,7 @@ trait Billable
         $this->cards()->each(function ($card) {
             $card->delete();
         });
-        
+
         $this->updateCardFromStripe();
     }
 

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -15,8 +15,8 @@ use Stripe\Customer as StripeCustomer;
 use Stripe\BankAccount as StripeBankAccount;
 use Stripe\InvoiceItem as StripeInvoiceItem;
 use Stripe\Error\InvalidRequest as StripeErrorInvalidRequest;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 trait Billable
 {


### PR DESCRIPTION
Ensures that the `customer_id` (`stripe_id` within cashier) matches the `customer_id` which is returned from the Stripe invoice.

Not checking this poses a security risk in a scenario where `invoice_id`'s are exposed, which the [documentation suggests](https://laravel.com/docs/5.5/billing#invoices).

If you would like a unit test for this let me know. I think the easiest way to test it would be to create a second user and attempt to access an invoice from the first user which will now throw an `AccessDeniedHttpException`.