### PR TITLE
Update stripe sdk to 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/database": "~5.3",
         "illuminate/support": "~5.3",
         "nesbot/carbon": "~1.0",
-        "stripe/stripe-php": "~5.0",
+        "stripe/stripe-php": "~6.0",
         "symfony/http-kernel": "~2.7|~3.0|~4.0"
     },
     "require-dev": {


### PR DESCRIPTION
As changelog of stripe https://github.com/stripe/stripe-php/blob/master/CHANGELOG.md, the major breaking changes are 
1. The minimum PHP version is now 5.4.0. 
2. \Stripe\AttachedObject no longer exists. 
which we shouldn't be affected.