### PR TITLE
[Fix] Remove unnecessary storage path variable

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -290,12 +290,11 @@ trait Billable
      *
      * @param  string  $id
      * @param  array  $data
-     * @param  string  $storagePath
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function downloadInvoice($id, array $data, $storagePath = null)
+    public function downloadInvoice($id, array $data)
     {
-        return $this->findInvoiceOrFail($id)->download($data, $storagePath);
+        return $this->findInvoiceOrFail($id)->download($data);
     }
 
     /**


### PR DESCRIPTION
The [`download`](https://github.com/laravel/cashier/blob/master/src/Invoice.php#L274) function on `Laravel\Cashier\Invoice` only accepts one argument: `array $data`

Targeting `master` as this may be a breaking change due to the API changing for the public `downloadInvoice` function, although I guess it isn't *really* breaking as it wouldn't do anything passing it, and it won't break if you continue to pass it 🤷‍♂️ Let me know if another branch is more suitable.

PS: Thank you for creating and maintaining Cashier.