### PR TITLE
[WIP] Clarify the difference in active vs valid states

### DIFF
--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -331,6 +331,47 @@ class CashierTest extends TestCase
         $this->assertEquals(1000, $refund->amount);
     }
 
+    public function testStateCheckMethods()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        // State: on trial
+        $subscription = $user->newSubscription('main', 'monthly-10-1')
+                ->trialDays(10)
+                ->create($this->getTestToken());
+
+        $this->assertTrue($subscription->active());
+        $this->assertTrue($subscription->valid());
+
+        // State: on trial + cancelled
+        $subscription->cancel();
+
+        $this->assertTrue($subscription->active());
+        $this->assertTrue($subscription->valid());
+
+        // State: recurring
+        $subscription = $user->newSubscription('main', 'monthly-10-1')
+                ->create($this->getTestToken());
+
+        $this->assertTrue($subscription->active());
+        $this->assertTrue($subscription->valid());
+
+        // State: recurring + cancelled
+        $subscription->cancel();
+
+        $this->assertTrue($subscription->active());
+        $this->assertTrue($subscription->valid());
+
+        // State: ended
+        $subscription->cancelNow();
+
+        $this->assertFalse($subscription->active());
+        $this->assertFalse($subscription->valid());
+    }
+
     protected function getTestToken()
     {
         return \Stripe\Token::create([


### PR DESCRIPTION
Been using this on my latest project and found it **fantastic** to work with.

One hurdle I ran into was understanding the difference in `active()` vs `valid()` states for subscriptions. In trying to understand them I made this:

| |Trial|Trial + Cancelled|Recurring|Recurring + Cancelled|Cancelled [ended]|
|-|---- |-----------------|---------|---------------------|-----------------|
|`onTrial()`|✅|✅|❌|❌|❌|
|`active()`|✅|✅|✅|✅|❌|
|`valid()`|✅|✅|✅|✅|❌|
|`cancelled()`|❌|✅|❌|✅|✅|
|`onGracePeriod()`|❌|✅|❌|✅|❌|

Unless I am missing a potential state a subscription can be in - it seems that these methods will *always* return the same thing. The tests in this PR also pass - which confirm the results in the table.

My thinking is that an "active" subscription is one that you are going to make money off - i.e. it is going to renew.

A "valid" subscription is any subscription that has not ended, i.e. all active subscriptions and all subscriptions on a grace period.

Unless I'm missing something else - I think it would be good to fix the methods in the package and adjust the PR'd tests to match.

If you agree with my thinking let me know and I'll submit the fixes for you - otherwise I'm more than happy to adjust with your guidance on what `active` vs `valid` means to Cashier.

This has been submitted to `master` as I am unsure if the fix (if wanted) would be a breaking change or a bug fix.