### PR TITLE
[Proposal] Add test variables to phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,4 +15,8 @@
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <env name="STRIPE_SECRET" value=""/>
+        <env name="STRIPE_MODEL" value="Laravel\Cashier\Tests\Fixtures\User"/>
+    </php>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ You will need to set the following details locally and on your Stripe account in
     STRIPE_SECRET=
     STRIPE_MODEL=Laravel\Cashier\Tests\Fixtures\User
 
-You can set these in the `phpunit.xml`
+You can set these variables in the `phpunit.xml` file.
 
 ### Stripe
 

--- a/readme.md
+++ b/readme.md
@@ -23,9 +23,10 @@ You will need to set the following details locally and on your Stripe account in
 
 #### .env
 
-    STRIPE_KEY=
     STRIPE_SECRET=
     STRIPE_MODEL=Laravel\Cashier\Tests\Fixtures\User
+
+You can set these in the `phpunit.xml`
 
 ### Stripe
 


### PR DESCRIPTION
It took me a few minutes to work out where to put the test variables [mentioned in the readme](https://github.com/laravel/cashier#env).

I thought having them already setup might be nicer for others in the future. I also thought this might interfere with your testing setup - but perhaps if it does we can just comment them out - but leave them there as a guide for others.

I also removed the `STRIPE_KEY` from the readme as this is not required to run the unit tests.