### PR TITLE
[Fix] Docblock return type

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -211,7 +211,7 @@ trait Billable
     /**
      * Get all of the subscriptions for the Stripe model.
      *
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
     public function subscriptions()
     {


### PR DESCRIPTION
`$billable->subscriptions()` returns a `HasMany` relation.

`$billable->subscriptions` returns the collection - as I'm sure you already know 😅