### PR TITLE
[7.0] Reuse existing class variable

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -55,11 +55,9 @@ class Subscription extends Model
      */
     public function owner()
     {
-        $model = getenv('STRIPE_MODEL') ?: config('services.stripe.model', 'App\\User');
+        $class = getenv('STRIPE_MODEL') ?: config('services.stripe.model', 'App\\User');
 
-        $model = new $model;
-
-        return $this->belongsTo(get_class($model), $model->getForeignKey());
+        return $this->belongsTo($class, (new $class)->getForeignKey());
     }
 
     /**


### PR DESCRIPTION
Tweaked this method to reuse the already retrieved class - instead of determining it from the "newed" up model and calling `get_class` on it.

✅ Tests are passing.