### PR TITLE
[7.0] More readable date checks

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -3,7 +3,6 @@
 namespace Laravel\Cashier;
 
 use Exception;
-use Carbon\Carbon;
 use InvalidArgumentException;
 use Stripe\Card as StripeCard;
 use Stripe\Token as StripeToken;
@@ -166,7 +165,7 @@ trait Billable
      */
     public function onGenericTrial()
     {
-        return $this->trial_ends_at && Carbon::now()->lt($this->trial_ends_at);
+        return $this->trial_ends_at && $this->trial_ends_at->isFuture();
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -119,11 +119,7 @@ class Subscription extends Model
      */
     public function onTrial()
     {
-        if (! is_null($this->trial_ends_at)) {
-            return Carbon::now()->lt($this->trial_ends_at);
-        } else {
-            return false;
-        }
+        return $this->trial_ends_at && $this->trial_ends_at->isFuture();
     }
 
     /**
@@ -133,11 +129,7 @@ class Subscription extends Model
      */
     public function onGracePeriod()
     {
-        if (! is_null($endsAt = $this->ends_at)) {
-            return Carbon::now()->lt(Carbon::instance($endsAt));
-        } else {
-            return false;
-        }
+        return $this->ends_at && $this->ends_at->isFuture();
     }
 
     /**


### PR DESCRIPTION
Carbon offers `isFuture()` and `isPast()` methods that make understanding the logic of date checks much nicer IMO and cleans up these methods to simple, readable one liners.

✅ Tests are passing.