### PR TITLE
Add Stripe Connect functionality

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,6 +17,7 @@
     </testsuites>
     <php>
         <env name="STRIPE_SECRET" value=""/>
+        <env name="STRIPE_CONNECT_ACCOUNT_ID" value=""/>
         <env name="STRIPE_MODEL" value="Laravel\Cashier\Tests\Fixtures\User"/>
     </php>
 </phpunit>

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -27,6 +27,13 @@ trait Billable
     protected static $stripeKey;
 
     /**
+     * The Connect account ID key.
+     *
+     * @var string
+     */
+    protected $account_id;
+
+    /**
      * Make a "one off" charge on the customer for the given amount.
      *
      * @param  int  $amount
@@ -51,7 +58,7 @@ trait Billable
             throw new InvalidArgumentException('No payment source provided.');
         }
 
-        return StripeCharge::create($options, ['api_key' => $this->getStripeKey()]);
+        return StripeCharge::create($options, $this->getStripeOptions());
     }
 
     /**
@@ -67,7 +74,7 @@ trait Billable
     {
         $options['charge'] = $charge;
 
-        return StripeRefund::create($options, ['api_key' => $this->getStripeKey()]);
+        return StripeRefund::create($options, $this->getStripeOptions());
     }
 
     /**
@@ -104,7 +111,8 @@ trait Billable
         ], $options);
 
         return StripeInvoiceItem::create(
-            $options, ['api_key' => $this->getStripeKey()]
+            $options,
+            $this->getStripeOptions()
         );
     }
 
@@ -226,7 +234,7 @@ trait Billable
     {
         if ($this->stripe_id) {
             try {
-                return StripeInvoice::create(['customer' => $this->stripe_id], $this->getStripeKey())->pay();
+                return StripeInvoice::create(['customer' => $this->stripe_id], $this->getStripeOptions())->pay();
             } catch (StripeErrorInvalidRequest $e) {
                 return false;
             }
@@ -244,7 +252,8 @@ trait Billable
     {
         try {
             $stripeInvoice = StripeInvoice::upcoming(
-                ['customer' => $this->stripe_id], ['api_key' => $this->getStripeKey()]
+                ['customer' => $this->stripe_id],
+                $this->getStripeOptions()
             );
 
             return new Invoice($this, $stripeInvoice);
@@ -262,7 +271,7 @@ trait Billable
     public function findInvoice($id)
     {
         try {
-            return new Invoice($this, StripeInvoice::retrieve($id, $this->getStripeKey()));
+            return new Invoice($this, StripeInvoice::retrieve($id, $this->getStripeOptions()));
         } catch (Exception $e) {
             //
         }
@@ -395,7 +404,7 @@ trait Billable
     {
         $customer = $this->asStripeCustomer();
 
-        $token = StripeToken::retrieve($token, ['api_key' => $this->getStripeKey()]);
+        $token = StripeToken::retrieve($token, $this->getStripeOptions());
 
         // If the given token already has the card as their default source, we can just
         // bail out of the method now. We don't need to keep adding the same card to
@@ -554,7 +563,8 @@ trait Billable
         // user from Stripe. This ID will correspond with the Stripe user instances
         // and allow us to retrieve users from Stripe later when we need to work.
         $customer = StripeCustomer::create(
-            $options, $this->getStripeKey()
+            $options,
+            $this->getStripeOptions()
         );
 
         $this->stripe_id = $customer->id;
@@ -578,7 +588,7 @@ trait Billable
      */
     public function asStripeCustomer()
     {
-        return StripeCustomer::retrieve($this->stripe_id, $this->getStripeKey());
+        return StripeCustomer::retrieve($this->stripe_id, $this->getStripeOptions());
     }
 
     /**
@@ -599,6 +609,29 @@ trait Billable
     public function taxPercentage()
     {
         return 0;
+    }
+
+    /**
+     * Set a Connect account to process the charges
+     *
+     * @param  string  $account_id
+     * @return void
+     */
+    public function billingAccount($account_id)
+    {
+        $this->account_id = $account_id;
+        return $this;
+    }
+
+    public function getStripeOptions()
+    {
+        $options = ['api_key' => $this->getStripeKey()];
+        if($this->account_id) {
+            $options = array_merge($options, [
+                'stripe_account' => $this->account_id,
+            ]);
+        }
+        return $options;
     }
 
     /**

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -390,8 +390,6 @@ trait Billable
                 return $card;
             }
         }
-
-        return null;
     }
 
     /**
@@ -612,7 +610,7 @@ trait Billable
     }
 
     /**
-     * Set a Connect account to process the charges
+     * Set a Connect account to process the charges.
      *
      * @param  string  $account_id
      * @return void
@@ -620,17 +618,19 @@ trait Billable
     public function billingAccount($account_id)
     {
         $this->account_id = $account_id;
+
         return $this;
     }
 
     public function getStripeOptions()
     {
         $options = ['api_key' => $this->getStripeKey()];
-        if($this->account_id) {
+        if ($this->account_id) {
             $options = array_merge($options, [
                 'stripe_account' => $this->account_id,
             ]);
         }
+
         return $options;
     }
 

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -173,7 +173,7 @@ class SubscriptionBuilder
     }
 
     /**
-     * If you are using Stripe Connect, you can add an application fee to the subscription
+     * If you are using Stripe Connect, you can add an application fee to the subscription.
      *
      * @param  int  $percentage
      * @return \Laravel\Cashier\Subscription

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -63,6 +63,13 @@ class SubscriptionBuilder
     protected $metadata;
 
     /**
+     * The Stripe Connect application fee to apply to the subscription.
+     *
+     * @var int|null
+     */
+    protected $application_fee_percent = null;
+
+    /**
      * Create a new subscription builder instance.
      *
      * @param  mixed  $owner
@@ -166,6 +173,19 @@ class SubscriptionBuilder
     }
 
     /**
+     * If you are using Stripe Connect, you can add an application fee to the subscription
+     *
+     * @param  int  $percentage
+     * @return \Laravel\Cashier\Subscription
+     */
+    public function applicationFeePercent($percentage)
+    {
+        $this->application_fee_percent = $percentage;
+
+        return $this;
+    }
+
+    /**
      * Create a new Stripe subscription.
      *
      * @param  string|null  $token
@@ -229,6 +249,7 @@ class SubscriptionBuilder
             'coupon' => $this->coupon,
             'trial_end' => $this->getTrialEndForPayload(),
             'tax_percent' => $this->getTaxPercentageForPayload(),
+            'application_fee_percent' => $this->application_fee_percent,
             'metadata' => $this->metadata,
         ]);
     }

--- a/tests/ConnectTest.php
+++ b/tests/ConnectTest.php
@@ -1,0 +1,411 @@
+<?php
+
+namespace Laravel\Cashier\Tests;
+
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use PHPUnit_Framework_TestCase;
+use Laravel\Cashier\Tests\Fixtures\User;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Laravel\Cashier\Tests\Fixtures\CashierTestControllerStub;
+
+class ConnectTest extends PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        if (file_exists(__DIR__.'/../.env')) {
+            $dotenv = new \Dotenv\Dotenv(__DIR__.'/../');
+            $dotenv->load();
+        }
+    }
+
+    public function setUp()
+    {
+        Eloquent::unguard();
+
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->string('name');
+            $table->string('stripe_id')->nullable();
+            $table->string('card_brand')->nullable();
+            $table->string('card_last_four')->nullable();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('subscriptions', function ($table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->string('name');
+            $table->string('stripe_id');
+            $table->string('stripe_plan');
+            $table->integer('quantity');
+            $table->timestamp('trial_ends_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function tearDown()
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('subscriptions');
+    }
+
+    /**
+     * Tests.
+     */
+    public function testSubscriptionsChargedApplicationFee()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        $application_fee_percent = rand(1,100);
+        // Create Subscription
+        $user
+            ->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'))
+            ->newSubscription('main', 'monthly-10-1')
+            ->applicationFeePercent($application_fee_percent)
+            ->create($this->getTestToken($user));
+
+        $subscription = $user->subscription('main');
+        $subscription->user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'));
+        $this->assertEquals($application_fee_percent, $subscription->asStripeSubscription()->application_fee_percent);
+    }
+    
+    public function testSubscriptionsCanBeCreated()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        // Create Subscription
+        $user
+            ->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'))
+            ->newSubscription('main', 'monthly-10-1')
+            ->create($this->getTestToken($user));
+            
+        $this->assertEquals(1, count($user->subscriptions));
+        $this->assertNotNull($user->subscription('main')->stripe_id);
+
+        $this->assertTrue($user->subscribed('main'));
+        $this->assertTrue($user->subscribedToPlan('monthly-10-1', 'main'));
+        $this->assertFalse($user->subscribedToPlan('monthly-10-1', 'something'));
+        $this->assertFalse($user->subscribedToPlan('monthly-10-2', 'main'));
+        $this->assertTrue($user->subscribed('main', 'monthly-10-1'));
+        $this->assertFalse($user->subscribed('main', 'monthly-10-2'));
+        $this->assertTrue($user->subscription('main')->active());
+        $this->assertFalse($user->subscription('main')->cancelled());
+        $this->assertFalse($user->subscription('main')->onGracePeriod());
+        $this->assertTrue($user->subscription('main')->recurring());
+        $this->assertFalse($user->subscription('main')->ended());
+
+        // Cancel Subscription
+        $subscription = $user->subscription('main');
+        $subscription->user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'));
+        $subscription->cancel();
+
+        $this->assertTrue($subscription->active());
+        $this->assertTrue($subscription->cancelled());
+        $this->assertTrue($subscription->onGracePeriod());
+        $this->assertFalse($subscription->recurring());
+        $this->assertFalse($subscription->ended());
+
+        // Modify Ends Date To Past
+        $oldGracePeriod = $subscription->ends_at;
+        $subscription->fill(['ends_at' => Carbon::now()->subDays(5)])->save();
+
+        $this->assertFalse($subscription->active());
+        $this->assertTrue($subscription->cancelled());
+        $this->assertFalse($subscription->onGracePeriod());
+        $this->assertFalse($subscription->recurring());
+        $this->assertTrue($subscription->ended());
+
+        $subscription->fill(['ends_at' => $oldGracePeriod])->save();
+
+        // Resume Subscription
+        $subscription->resume();
+
+        $this->assertTrue($subscription->active());
+        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->onGracePeriod());
+        $this->assertTrue($subscription->recurring());
+        $this->assertFalse($subscription->ended());
+
+        // Increment & Decrement
+        $subscription->incrementQuantity();
+
+        $this->assertEquals(2, $subscription->quantity);
+
+        $subscription->decrementQuantity();
+
+        $this->assertEquals(1, $subscription->quantity);
+
+        // Swap Plan
+        $subscription->swap('monthly-10-2');
+
+        $this->assertEquals('monthly-10-2', $subscription->stripe_plan);
+
+        // Invoice Tests
+        $invoice = $user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'))->invoices()[1];
+
+        $this->assertEquals('$10.00', $invoice->total());
+        $this->assertFalse($invoice->hasDiscount());
+        $this->assertFalse($invoice->hasStartingBalance());
+        $this->assertNull($invoice->coupon());
+        $this->assertInstanceOf(Carbon::class, $invoice->date());
+    }
+
+    public function test_creating_subscription_with_coupons()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        // Create Subscription
+        $user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'))
+            ->newSubscription('main', 'monthly-10-1')
+            ->withCoupon('coupon-1')->create($this->getTestToken($user));
+
+        $subscription = $user->subscription('main');
+        $subscription->user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'));
+
+        $this->assertTrue($user->subscribed('main'));
+        $this->assertTrue($user->subscribed('main', 'monthly-10-1'));
+        $this->assertFalse($user->subscribed('main', 'monthly-10-2'));
+        $this->assertTrue($subscription->active());
+        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->onGracePeriod());
+        $this->assertTrue($subscription->recurring());
+        $this->assertFalse($subscription->ended());
+
+        // Invoice Tests
+        $invoice = $user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'))->invoices()[0];
+
+        $this->assertTrue($invoice->hasDiscount());
+        $this->assertEquals('$5.00', $invoice->total());
+        $this->assertEquals('$5.00', $invoice->amountOff());
+        $this->assertFalse($invoice->discountIsPercentage());
+    }
+
+    public function test_generic_trials()
+    {
+        $user = new User;
+        $user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'));
+        $this->assertFalse($user->onGenericTrial());
+        $user->trial_ends_at = Carbon::tomorrow();
+        $this->assertTrue($user->onGenericTrial());
+        $user->trial_ends_at = Carbon::today()->subDays(5);
+        $this->assertFalse($user->onGenericTrial());
+    }
+
+    public function test_creating_subscription_with_trial()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        // Create Subscription
+        $user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'))
+            ->newSubscription('main', 'monthly-10-1')
+            ->trialDays(7)->create($this->getTestToken($user));
+
+        $subscription = $user->subscription('main');
+        $subscription->user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'));
+
+        $this->assertTrue($subscription->active());
+        $this->assertTrue($subscription->onTrial());
+        $this->assertFalse($subscription->recurring());
+        $this->assertFalse($subscription->ended());
+        $this->assertEquals(Carbon::today()->addDays(7)->day, $subscription->trial_ends_at->day);
+
+        // Cancel Subscription
+        $subscription->cancel();
+
+        $this->assertTrue($subscription->active());
+        $this->assertTrue($subscription->onGracePeriod());
+        $this->assertFalse($subscription->recurring());
+        $this->assertFalse($subscription->ended());
+
+        // Resume Subscription
+        $subscription->resume();
+
+        $this->assertTrue($subscription->active());
+        $this->assertFalse($subscription->onGracePeriod());
+        $this->assertTrue($subscription->onTrial());
+        $this->assertFalse($subscription->recurring());
+        $this->assertFalse($subscription->ended());
+        $this->assertEquals(Carbon::today()->addDays(7)->day, $subscription->trial_ends_at->day);
+    }
+
+    public function test_creating_subscription_with_explicit_trial()
+    {
+        $user = User::create([
+             'email' => 'taylor@laravel.com',
+             'name' => 'Taylor Otwell',
+        ]);
+
+        // Create Subscription
+        $user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'))
+            ->newSubscription('main', 'monthly-10-1')
+            ->trialUntil(Carbon::tomorrow()->hour(3)->minute(15))->create($this->getTestToken($user));
+
+        $subscription = $user->subscription('main');
+        $subscription->user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'));
+
+        $this->assertTrue($subscription->active());
+        $this->assertTrue($subscription->onTrial());
+        $this->assertFalse($subscription->recurring());
+        $this->assertFalse($subscription->ended());
+        $this->assertEquals(Carbon::tomorrow()->hour(3)->minute(15), $subscription->trial_ends_at);
+
+        // Cancel Subscription
+        $subscription->cancel();
+
+        $this->assertTrue($subscription->active());
+        $this->assertTrue($subscription->onGracePeriod());
+        $this->assertFalse($subscription->recurring());
+        $this->assertFalse($subscription->ended());
+
+        // Resume Subscription
+        $subscription->resume();
+
+        $this->assertTrue($subscription->active());
+        $this->assertFalse($subscription->onGracePeriod());
+        $this->assertTrue($subscription->onTrial());
+        $this->assertFalse($subscription->recurring());
+        $this->assertFalse($subscription->ended());
+        $this->assertEquals(Carbon::tomorrow()->hour(3)->minute(15), $subscription->trial_ends_at);
+    }
+
+    public function test_applying_coupons_to_existing_customers()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        // Create Subscription
+        $user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'))
+            ->newSubscription('main', 'monthly-10-1')
+            ->create($this->getTestToken($user));
+
+        $user->applyCoupon('coupon-1');
+
+        $customer = $user->asStripeCustomer();
+
+        $this->assertEquals('coupon-1', $customer->discount->coupon->id);
+    }
+
+    /**
+     * @group foo
+     */
+    public function test_marking_as_cancelled_from_webhook()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        $user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'))
+            ->newSubscription('main', 'monthly-10-1')
+            ->create($this->getTestToken($user));
+
+        $subscription = $user->subscription('main');
+        $subscription->user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'));
+
+        $request = Request::create('/', 'POST', [], [], [], [], json_encode(['id' => 'foo', 'type' => 'customer.subscription.deleted',
+            'data' => [
+                'object' => [
+                    'id' => $subscription->stripe_id,
+                    'customer' => $user->stripe_id,
+                ],
+            ],
+        ]));
+
+        $controller = new CashierTestControllerStub;
+        $response = $controller->handleWebhook($request);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $user = $user->fresh();
+        $subscription = $user->subscription('main');
+
+        $this->assertTrue($subscription->cancelled());
+    }
+
+    public function testCreatingOneOffInvoices()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        // Create Invoice
+        $user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'))
+            ->createAsStripeCustomer($this->getTestToken($user));
+        $user->invoiceFor('Laravel Cashier', 1000);
+
+        // Invoice Tests
+        $invoice = $user->invoices()[0];
+        $this->assertEquals('$10.00', $invoice->total());
+        $this->assertEquals('Laravel Cashier', $invoice->invoiceItems()[0]->asStripeInvoiceItem()->description);
+    }
+
+    public function testRefunds()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        // Create Invoice
+        $user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'))
+            ->createAsStripeCustomer($this->getTestToken($user));
+        $invoice = $user->invoiceFor('Laravel Cashier', 1000);
+
+        // Create the refund
+        $refund = $user->refund($invoice->charge);
+
+        // Refund Tests
+        $this->assertEquals(1000, $refund->amount);
+    }
+
+    protected function getTestToken($user)
+    {
+        return \Stripe\Token::create([
+            'card' => [
+                'number' => '4242424242424242',
+                'exp_month' => 5,
+                'exp_year' => 2020,
+                'cvc' => '123',
+            ],
+        ], $user->getStripeOptions())->id;
+    }
+
+    /**
+     * Schema Helpers.
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+}

--- a/tests/ConnectTest.php
+++ b/tests/ConnectTest.php
@@ -71,7 +71,7 @@ class ConnectTest extends PHPUnit_Framework_TestCase
             'name' => 'Taylor Otwell',
         ]);
 
-        $application_fee_percent = rand(1,100);
+        $application_fee_percent = rand(1, 100);
         // Create Subscription
         $user
             ->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'))
@@ -83,7 +83,7 @@ class ConnectTest extends PHPUnit_Framework_TestCase
         $subscription->user->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'));
         $this->assertEquals($application_fee_percent, $subscription->asStripeSubscription()->application_fee_percent);
     }
-    
+
     public function testSubscriptionsCanBeCreated()
     {
         $user = User::create([
@@ -96,7 +96,7 @@ class ConnectTest extends PHPUnit_Framework_TestCase
             ->billingAccount(getenv('STRIPE_CONNECT_ACCOUNT_ID'))
             ->newSubscription('main', 'monthly-10-1')
             ->create($this->getTestToken($user));
-            
+
         $this->assertEquals(1, count($user->subscriptions));
         $this->assertNotNull($user->subscription('main')->stripe_id);
 


### PR DESCRIPTION
Adds functionality for Stripe Connect, as discussed in: #410 #406 #399 #202 

The account ID can be specified with something like:

```bash
$user->billingAccount($account_id)->subscription('main');
```

and an application fee can be added to a subscription:

```bash
$user
    ->billingAccount($account_id)
    ->newSubscription('main', $subscription_id)
    ->applicationFeePercent($application_fee_percent)
    ->create($token);
```