### PR TITLE
[7.0] Dry up stripe model retrieval

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -126,4 +126,9 @@ class Cashier
 
         return static::usesCurrencySymbol().$amount;
     }
+
+    public static function stripeModel()
+    {
+        return getenv('STRIPE_MODEL') ?: config('services.stripe.model', 'App\\User');
+    }
 }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier\Http\Controllers;
 
 use Exception;
 use Illuminate\Http\Request;
+use Laravel\Cashier\Cashier;
 use Stripe\Event as StripeEvent;
 use Illuminate\Routing\Controller;
 use Symfony\Component\HttpFoundation\Response;
@@ -62,7 +63,7 @@ class WebhookController extends Controller
      */
     protected function getUserByStripeId($stripeId)
     {
-        $model = getenv('STRIPE_MODEL') ?: config('services.stripe.model');
+        $model = Cashier::stripeModel();
 
         return (new $model)->where('stripe_id', $stripeId)->first();
     }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -55,7 +55,7 @@ class Subscription extends Model
      */
     public function owner()
     {
-        $class = getenv('STRIPE_MODEL') ?: config('services.stripe.model', 'App\\User');
+        $class = Cashier::stripeModel();
 
         return $this->belongsTo($class, (new $class)->getForeignKey());
     }


### PR DESCRIPTION
The retrieval of the stripe model class is a bit more than a simple config call so it felt nicer in its own method.

Note that at some point these got out of sync (another benefit to making a dedicated method call) and `src/Subscription.php` file has a fallback default `'App\\User'` which will now be in place for web hook call.

Ran the tests against PHP7.2 and all sweet.