### PR TITLE
remove old dompdf custom configuration support

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -252,10 +252,6 @@ class Invoice
             define('DOMPDF_ENABLE_AUTOLOAD', false);
         }
 
-        if (file_exists($configPath = base_path().'/vendor/dompdf/dompdf/dompdf_config.inc.php')) {
-            require_once $configPath;
-        }
-
         $dompdf = new Dompdf;
 
         $dompdf->loadHtml($this->view($data)->render());


### PR DESCRIPTION
Cashier requires `"dompdf/dompdf": "^0.8.0"` but includes customisation support that was removed in `0.7.0`.  This can be misleading when customising invoice templates.

It's noted in the docs and by the maintainer in this reference.
https://github.com/dompdf/dompdf/issues/1351