### PR TITLE
Add ability to anchor a new subscription to a billing cycle date.

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -3,6 +3,7 @@
 namespace Laravel\Cashier;
 
 use Carbon\Carbon;
+use DateTimeInterface;
 
 class SubscriptionBuilder
 {
@@ -47,6 +48,13 @@ class SubscriptionBuilder
      * @var bool
      */
     protected $skipTrial = false;
+
+    /**
+     * The date on which the billing cycle should be anchored.
+     *
+     * @var string|null
+     */
+    protected $billingCycleAnchor = null;
 
     /**
      * The coupon code being applied to the customer.
@@ -124,6 +132,23 @@ class SubscriptionBuilder
     public function skipTrial()
     {
         $this->skipTrial = true;
+
+        return $this;
+    }
+
+    /**
+     * Change the billing cycle anchor on a plan creation.
+     *
+     * @param  \DateTimeInterface|int  $date
+     * @return $this
+     */
+    public function anchorBillingCycleOn($date)
+    {
+        if ($date instanceof DateTimeInterface) {
+            $date = $date->getTimestamp();
+        }
+
+        $this->billingCycleAnchor = $date;
 
         return $this;
     }
@@ -229,6 +254,7 @@ class SubscriptionBuilder
             'coupon' => $this->coupon,
             'trial_end' => $this->getTrialEndForPayload(),
             'tax_percent' => $this->getTaxPercentageForPayload(),
+            'billing_cycle_anchor' => $this->billingCycleAnchor,
             'metadata' => $this->metadata,
         ]);
     }


### PR DESCRIPTION
This allows you to anchor a new subscription to a specific date. For example, this allows you to anchor a new subscription to the 1st day of the next month. This makes the renewal date of the customer become the 1st of the month instead of on the day they initially signed up.

This feature already exists within Cashier for swapping subscriptions, but it wasn't there for new subscriptions. This fixes that.