### PR TITLE
Default to show coupon name instead of code

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -152,9 +152,9 @@
                     @if ($invoice->hasDiscount())
                         <tr>
                             @if ($invoice->discountIsPercentage())
-                                <td>{{ $invoice->coupon() }} ({{ $invoice->percentOff() }}% Off)</td>
+                                <td>{{ $invoice->couponName() }} ({{ $invoice->percentOff() }}% Off)</td>
                             @else
-                                <td>{{ $invoice->coupon() }} ({{ $invoice->amountOff() }} Off)</td>
+                                <td>{{ $invoice->couponName() }} ({{ $invoice->amountOff() }} Off)</td>
                             @endif
                             <td>&nbsp;</td>
                             <td>-{{ $invoice->discount() }}</td>

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -134,6 +134,18 @@ class Invoice
             return $this->invoice->discount->coupon->id;
         }
     }
+    
+    /**
+     * Get the coupon name applied to the invoice.
+     *
+     * @return string|null
+     */
+    public function couponName()
+    {
+        if (isset($this->invoice->discount)) {
+            return $this->invoice->discount->coupon->name;
+        }
+    }
 
     /**
      * Determine if the discount is a percentage.


### PR DESCRIPTION
When creating a coupon in Stripe the help text next to Coupon Id is: 

>  We recommend leaving this blank so we can generate an ID for you.

The generated codes are complex which seems to imply Stripe thinks you should make coupon codes hard to guess.

Showing coupon id on invoices by default instead of the more anonymous name seems like a good idea.