### PR TITLE
[WIP] Laravel Cashier Multi Plans

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -10,7 +10,7 @@ Pull requests for bugs may be sent without creating any proposal issue. If you b
 
 ### Feature Requests
 
-If you have an idea for a new feature you would like to see added to Laravel, you may create an issue on GitHub with `[Request]` in the title. The feature request will then be reviewed by @taylorotwell.
+If you have an idea for a new feature you would like to see added to Laravel Cashier, you may create an issue on GitHub with `[Request]` in the title. The feature request will then be reviewed by @taylorotwell.
 
 ## Coding Guidelines
 

--- a/readme.md
+++ b/readme.md
@@ -30,10 +30,14 @@ You can set these variables in the `phpunit.xml` file.
 
 ### Stripe
 
-#### Plans
+#### Products (Plans)
+
+Set the following as the product *id*
 
     * monthly-10-1 ($10)
     * monthly-10-2 ($10)
+    * monthly-10-3 ($10)
+    * monthly-10-4 ($10)
 
 #### Coupons
 

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -127,12 +127,12 @@ trait Billable
      * Begin creating a new subscription.
      *
      * @param  string  $subscription
-     * @param  string  $plan
+     * @param  string[]|string  $plan
      * @return \Laravel\Cashier\SubscriptionBuilder
      */
     public function newSubscription($subscription, $plan)
     {
-        return new SubscriptionBuilder($this, $subscription, $plan);
+        return new SubscriptionBuilder($this, $subscription, (array) $plan);
     }
 
     /**
@@ -188,7 +188,7 @@ trait Billable
         }
 
         return $subscription->valid() &&
-               $subscription->stripe_plan === $plan;
+               $subscription->hasPlan($plan);
     }
 
     /**
@@ -507,8 +507,11 @@ trait Billable
         }
 
         foreach ((array) $plans as $plan) {
-            if ($subscription->stripe_plan === $plan) {
-                return true;
+            foreach($subscription->subscriptionItems as $subscriptionItem)
+            {
+                if ($subscriptionItem->stripe_plan === $plan) {
+                    return true;
+                }
             }
         }
 

--- a/src/Exceptions/SubscriptionPlanNotFound.php
+++ b/src/Exceptions/SubscriptionPlanNotFound.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Cashier\Exceptions;
+
+use Throwable;
+
+/**
+ * Class SubscriptionPlanNotFound.
+ */
+final class SubscriptionPlanNotFound extends \Exception
+{
+    public function __construct($planKey, $subscriptionName)
+    {
+        parent::__construct("[{$planKey}] Not found on [{$subscriptionName}]");
+    }
+}

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Cashier;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class SubscriptionItem.
+ */
+final class SubscriptionItem extends Model
+{
+    /**
+     * The attributes that are not mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [
+        'created_at', 'updated_at',
+    ];
+}

--- a/tests/CashierBaseTest.php
+++ b/tests/CashierBaseTest.php
@@ -43,10 +43,17 @@ abstract class CashierBaseTest extends PHPUnit_Framework_TestCase
             $table->integer('user_id');
             $table->string('name');
             $table->string('stripe_id');
-            $table->string('stripe_plan');
-            $table->integer('quantity');
             $table->timestamp('trial_ends_at')->nullable();
             $table->timestamp('ends_at')->nullable();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('subscription_items', function ($table) {
+            $table->increments('id');
+            $table->integer('subscription_id');
+            $table->string('stripe_id');
+            $table->string('stripe_plan');
+            $table->integer('quantity');
             $table->timestamps();
         });
     }
@@ -55,6 +62,7 @@ abstract class CashierBaseTest extends PHPUnit_Framework_TestCase
     {
         $this->schema()->drop('users');
         $this->schema()->drop('subscriptions');
+        $this->schema()->drop('subscription_items');
     }
 
     protected function getTestToken()

--- a/tests/CashierBaseTest.php
+++ b/tests/CashierBaseTest.php
@@ -71,7 +71,7 @@ abstract class CashierBaseTest extends PHPUnit_Framework_TestCase
             'card' => [
                 'number' => '4242424242424242',
                 'exp_month' => 5,
-                'exp_year' => 2020,
+                'exp_year' => date('Y') + 1,
                 'cvc' => '123',
             ],
         ], ['api_key' => getenv('STRIPE_SECRET')])->id;

--- a/tests/CashierBaseTest.php
+++ b/tests/CashierBaseTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Laravel\Cashier\Tests;
+
+use PHPUnit_Framework_TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+abstract class CashierBaseTest extends PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        if (file_exists(__DIR__.'/../.env')) {
+            $dotenv = new \Dotenv\Dotenv(__DIR__.'/../');
+            $dotenv->load();
+        }
+    }
+
+    public function setUp()
+    {
+        Eloquent::unguard();
+
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->string('name');
+            $table->string('stripe_id')->nullable();
+            $table->string('card_brand')->nullable();
+            $table->string('card_last_four')->nullable();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('subscriptions', function ($table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->string('name');
+            $table->string('stripe_id');
+            $table->string('stripe_plan');
+            $table->integer('quantity');
+            $table->timestamp('trial_ends_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function tearDown()
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('subscriptions');
+    }
+
+    protected function getTestToken()
+    {
+        return \Stripe\Token::create([
+            'card' => [
+                'number' => '4242424242424242',
+                'exp_month' => 5,
+                'exp_year' => 2020,
+                'cvc' => '123',
+            ],
+        ], ['api_key' => getenv('STRIPE_SECRET')])->id;
+    }
+
+    /**
+     * Schema Helpers.
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+}

--- a/tests/CashierMultiplePlanTest.php
+++ b/tests/CashierMultiplePlanTest.php
@@ -8,9 +8,9 @@ use Laravel\Cashier\Tests\Fixtures\User;
 use Laravel\Cashier\Tests\Fixtures\CashierTestControllerStub;
 
 /**
- * Class CashierSinglePlanTest.
+ * Class CashierMultiplePlanTest
  */
-final class CashierSinglePlanTest extends CashierBaseTest
+final class CashierMultiplePlanTest extends CashierBaseTest
 {
     /**
      * Tests.
@@ -26,7 +26,7 @@ final class CashierSinglePlanTest extends CashierBaseTest
         );
 
         // Create Subscription
-        $user->newSubscription('main', 'monthly-10-1')->create($this->getTestToken());
+        $user->newSubscription('main', ['monthly-10-1', 'monthly-10-2'])->create($this->getTestToken());
 
         $this->assertEquals(1, count($user->subscriptions));
         $this->assertNotNull($user->subscription('main')->stripe_id);
@@ -34,9 +34,9 @@ final class CashierSinglePlanTest extends CashierBaseTest
         $this->assertTrue($user->subscribed('main'));
         $this->assertTrue($user->subscribedToPlan('monthly-10-1', 'main'));
         $this->assertFalse($user->subscribedToPlan('monthly-10-1', 'something'));
-        $this->assertFalse($user->subscribedToPlan('monthly-10-2', 'main'));
+        $this->assertFalse($user->subscribedToPlan('monthly-10-3', 'main'));
         $this->assertTrue($user->subscribed('main', 'monthly-10-1'));
-        $this->assertFalse($user->subscribed('main', 'monthly-10-2'));
+        $this->assertFalse($user->subscribed('main', 'monthly-10-3'));
         $this->assertTrue($user->subscription('main')->active());
         $this->assertFalse($user->subscription('main')->cancelled());
         $this->assertFalse($user->subscription('main')->onGracePeriod());

--- a/tests/CashierSinglePlanTest.php
+++ b/tests/CashierSinglePlanTest.php
@@ -4,72 +4,25 @@ namespace Laravel\Cashier\Tests;
 
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use PHPUnit_Framework_TestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
-use Illuminate\Database\Capsule\Manager as DB;
-use Illuminate\Database\Eloquent\Model as Eloquent;
 use Laravel\Cashier\Tests\Fixtures\CashierTestControllerStub;
 
-class CashierTest extends PHPUnit_Framework_TestCase
+/**
+ * Class CashierSinglePlanTest.
+ */
+final class CashierSinglePlanTest extends CashierBaseTest
 {
-    public static function setUpBeforeClass()
-    {
-        if (file_exists(__DIR__.'/../.env')) {
-            $dotenv = new \Dotenv\Dotenv(__DIR__.'/../');
-            $dotenv->load();
-        }
-    }
-
-    public function setUp()
-    {
-        Eloquent::unguard();
-
-        $db = new DB;
-        $db->addConnection([
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-        ]);
-        $db->bootEloquent();
-        $db->setAsGlobal();
-
-        $this->schema()->create('users', function ($table) {
-            $table->increments('id');
-            $table->string('email');
-            $table->string('name');
-            $table->string('stripe_id')->nullable();
-            $table->string('card_brand')->nullable();
-            $table->string('card_last_four')->nullable();
-            $table->timestamps();
-        });
-
-        $this->schema()->create('subscriptions', function ($table) {
-            $table->increments('id');
-            $table->integer('user_id');
-            $table->string('name');
-            $table->string('stripe_id');
-            $table->string('stripe_plan');
-            $table->integer('quantity');
-            $table->timestamp('trial_ends_at')->nullable();
-            $table->timestamp('ends_at')->nullable();
-            $table->timestamps();
-        });
-    }
-
-    public function tearDown()
-    {
-        $this->schema()->drop('users');
-        $this->schema()->drop('subscriptions');
-    }
-
     /**
      * Tests.
      */
     public function testSubscriptionsCanBeCreated()
     {
-        $user = User::create([
-            'email' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ]);
+        $user = User::create(
+            [
+                'email' => 'taylor@laravel.com',
+                'name'  => 'Taylor Otwell',
+            ]
+        );
 
         // Create Subscription
         $user->newSubscription('main', 'monthly-10-1')->create($this->getTestToken());
@@ -146,14 +99,16 @@ class CashierTest extends PHPUnit_Framework_TestCase
 
     public function test_creating_subscription_with_coupons()
     {
-        $user = User::create([
-            'email' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ]);
+        $user = User::create(
+            [
+                'email' => 'taylor@laravel.com',
+                'name'  => 'Taylor Otwell',
+            ]
+        );
 
         // Create Subscription
         $user->newSubscription('main', 'monthly-10-1')
-                ->withCoupon('coupon-1')->create($this->getTestToken());
+             ->withCoupon('coupon-1')->create($this->getTestToken());
 
         $subscription = $user->subscription('main');
 
@@ -177,15 +132,17 @@ class CashierTest extends PHPUnit_Framework_TestCase
 
     public function test_creating_subscription_with_an_anchored_billing_cycle()
     {
-        $user = User::create([
-            'email' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ]);
+        $user = User::create(
+            [
+                'email' => 'taylor@laravel.com',
+                'name'  => 'Taylor Otwell',
+            ]
+        );
 
         // Create Subscription
         $user->newSubscription('main', 'monthly-10-1')
-            ->anchorBillingCycleOn(new \DateTime('first day of next month'))
-            ->create($this->getTestToken());
+             ->anchorBillingCycleOn(new \DateTime('first day of next month'))
+             ->create($this->getTestToken());
 
         $subscription = $user->subscription('main');
 
@@ -224,14 +181,16 @@ class CashierTest extends PHPUnit_Framework_TestCase
 
     public function test_creating_subscription_with_trial()
     {
-        $user = User::create([
-            'email' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ]);
+        $user = User::create(
+            [
+                'email' => 'taylor@laravel.com',
+                'name'  => 'Taylor Otwell',
+            ]
+        );
 
         // Create Subscription
         $user->newSubscription('main', 'monthly-10-1')
-                ->trialDays(7)->create($this->getTestToken());
+             ->trialDays(7)->create($this->getTestToken());
 
         $subscription = $user->subscription('main');
 
@@ -262,10 +221,12 @@ class CashierTest extends PHPUnit_Framework_TestCase
 
     public function test_creating_subscription_with_explicit_trial()
     {
-        $user = User::create([
-             'email' => 'taylor@laravel.com',
-             'name' => 'Taylor Otwell',
-        ]);
+        $user = User::create(
+            [
+                'email' => 'taylor@laravel.com',
+                'name'  => 'Taylor Otwell',
+            ]
+        );
 
         // Create Subscription
         $user->newSubscription('main', 'monthly-10-1')
@@ -300,14 +261,16 @@ class CashierTest extends PHPUnit_Framework_TestCase
 
     public function test_applying_coupons_to_existing_customers()
     {
-        $user = User::create([
-            'email' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ]);
+        $user = User::create(
+            [
+                'email' => 'taylor@laravel.com',
+                'name'  => 'Taylor Otwell',
+            ]
+        );
 
         // Create Subscription
         $user->newSubscription('main', 'monthly-10-1')
-                ->create($this->getTestToken());
+             ->create($this->getTestToken());
 
         $user->applyCoupon('coupon-1');
 
@@ -321,24 +284,38 @@ class CashierTest extends PHPUnit_Framework_TestCase
      */
     public function test_marking_as_cancelled_from_webhook()
     {
-        $user = User::create([
-            'email' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ]);
+        $user = User::create(
+            [
+                'email' => 'taylor@laravel.com',
+                'name'  => 'Taylor Otwell',
+            ]
+        );
 
         $user->newSubscription('main', 'monthly-10-1')
-                ->create($this->getTestToken());
+             ->create($this->getTestToken());
 
         $subscription = $user->subscription('main');
 
-        $request = Request::create('/', 'POST', [], [], [], [], json_encode(['id' => 'foo', 'type' => 'customer.subscription.deleted',
-            'data' => [
-                'object' => [
-                    'id' => $subscription->stripe_id,
-                    'customer' => $user->stripe_id,
-                ],
-            ],
-        ]));
+        $request = Request::create(
+            '/',
+            'POST',
+            [],
+            [],
+            [],
+            [],
+            json_encode(
+                [
+                    'id'   => 'foo',
+                    'type' => 'customer.subscription.deleted',
+                    'data' => [
+                        'object' => [
+                            'id'       => $subscription->stripe_id,
+                            'customer' => $user->stripe_id,
+                        ],
+                    ],
+                ]
+            )
+        );
 
         $controller = new CashierTestControllerStub;
         $response = $controller->handleWebhook($request);
@@ -352,10 +329,12 @@ class CashierTest extends PHPUnit_Framework_TestCase
 
     public function testCreatingOneOffInvoices()
     {
-        $user = User::create([
-            'email' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ]);
+        $user = User::create(
+            [
+                'email' => 'taylor@laravel.com',
+                'name'  => 'Taylor Otwell',
+            ]
+        );
 
         // Create Invoice
         $user->createAsStripeCustomer($this->getTestToken());
@@ -369,10 +348,12 @@ class CashierTest extends PHPUnit_Framework_TestCase
 
     public function testRefunds()
     {
-        $user = User::create([
-            'email' => 'taylor@laravel.com',
-            'name' => 'Taylor Otwell',
-        ]);
+        $user = User::create(
+            [
+                'email' => 'taylor@laravel.com',
+                'name'  => 'Taylor Otwell',
+            ]
+        );
 
         // Create Invoice
         $user->createAsStripeCustomer($this->getTestToken());
@@ -383,30 +364,5 @@ class CashierTest extends PHPUnit_Framework_TestCase
 
         // Refund Tests
         $this->assertEquals(1000, $refund->amount);
-    }
-
-    protected function getTestToken()
-    {
-        return \Stripe\Token::create([
-            'card' => [
-                'number' => '4242424242424242',
-                'exp_month' => 5,
-                'exp_year' => 2020,
-                'cvc' => '123',
-            ],
-        ], ['api_key' => getenv('STRIPE_SECRET')])->id;
-    }
-
-    /**
-     * Schema Helpers.
-     */
-    protected function schema()
-    {
-        return $this->connection()->getSchemaBuilder();
-    }
-
-    protected function connection()
-    {
-        return Eloquent::getConnectionResolver()->connection();
     }
 }


### PR DESCRIPTION
As discussed add support for multiple plans tied to a single subscription. 

- [x] Plan DB schema
- [ ] Create subscription allow multipul  plans to be defined
- [ ] Update Documents
- [ ] Migration command from cashier 7.0 to 8.0?
- [ ] Bonus Plan usage reporting (metered billing)

Other Similar PR
- https://github.com/laravel/cashier/pull/420
- https://github.com/laravel/cashier/pull/398