### PR TITLE
[Proposal] New collection to allow shortcuts to filters

### DIFF
--- a/src/SubscribersCollection.php
+++ b/src/SubscribersCollection.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Laravel\Cashier;
+
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Class SubscribersCollection
+ *
+ * @package App\Support
+ */
+class Subscriptions extends Collection
+{
+    /**
+     * @return $this
+     */
+    public function onTrial()
+    {
+        return $this->filter->onTrial();
+    }
+
+    /**
+     * @param string $subscription
+     *
+     * @return $this
+     */
+    public function subscribed($subscription = 'default')
+    {
+        return $this->filter->subscribed($subscription);
+    }
+}

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -41,6 +41,18 @@ class Subscription extends Model
     protected $billingCycleAnchor = null;
 
     /**
+     * Create a new Subscriptions Collection instance.
+     *
+     * @param  array $models
+     *
+     * @return Subscriptions
+     */
+    public function newCollection(array $models = [])
+    {
+        return new Subscriptions($models);
+    }
+
+    /**
      * Get the user that owns the subscription.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
@@ -353,7 +365,7 @@ class Subscription extends Model
         }
 
         $subscription = $this->asStripeSubscription();
-        
+
         $subscription->cancel_at_period_end = false;
 
         // To resume the subscription we need to set the plan parameter on the Stripe

--- a/src/Subscriptions.php
+++ b/src/Subscriptions.php
@@ -4,11 +4,6 @@ namespace Laravel\Cashier;
 
 use Illuminate\Database\Eloquent\Collection;
 
-/**
- * Class SubscribersCollection
- *
- * @package App\Support
- */
 class Subscriptions extends Collection
 {
     /**


### PR DESCRIPTION
It would be nice to have shorthands to filter the subscriptions like...

`Laravel\Cashier\Subscription::all()->onTrial()`

instead of...

`Laravel\Cashier\Subscription::all()->filter->onTrial()`

I was not sure if you would see the value or just prefer to leave it out, so I am making this a `WIP` to see what you think before adding the other helpers & doing test.

If you like it, just let me know & I will polish it off.  Otherwise, please close.

Thanks!