### PR TITLE
Fix subscription cancel()

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -295,7 +295,8 @@ class Subscription extends Model
     {
         $subscription = $this->asStripeSubscription();
 
-        $subscription->cancel(['at_period_end' => true]);
+        $subscription->cancel_at_period_end = true;
+        $subscription->save();
 
         // If the user was on trial, we will set the grace period to end when the trial
         // would have ended. Otherwise, we'll retrieve the end of the billing period


### PR DESCRIPTION
Fix subscription cancel method, so it works with stripe api version 2018-08-23

More info here https://stripe.com/docs/upgrades#2018-08-23