### PR TITLE
[7.0] Handle more webhooks to keep database consistency

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -175,7 +175,7 @@ class WebhookController extends Controller
     }
 
     /**
-     * Handle customer source deleted
+     * Handle customer source deleted.
      *
      * @param  array $payload
      * @return \Symfony\Component\HttpFoundation\Response

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -115,7 +115,7 @@ class WebhookController extends Controller
                 if (isset($data['trial_end'])) {
                     $trial_ends = Carbon::createFromTimestamp($data['trial_end']);
 
-                    if ($subscription->trial_ends_at->ne($trial_ends)) {
+                    if (! $subscription->trial_ends_at || $subscription->trial_ends_at->ne($trial_ends)) {
                         $subscription->trial_ends_at = $trial_ends;
                     }
                 }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -5,9 +5,9 @@ namespace Laravel\Cashier\Http\Controllers;
 use Exception;
 use Illuminate\Http\Request;
 use Laravel\Cashier\Cashier;
+use Illuminate\Support\Carbon;
 use Stripe\Event as StripeEvent;
 use Illuminate\Routing\Controller;
-use Illuminate\Support\Carbon;
 use Symfony\Component\HttpFoundation\Response;
 
 class WebhookController extends Controller
@@ -57,7 +57,7 @@ class WebhookController extends Controller
     }
 
     /**
-     * Handle deleted customer
+     * Handle deleted customer.
      *
      * @param  array $payload
      * @return \Symfony\Component\HttpFoundation\Response
@@ -78,7 +78,7 @@ class WebhookController extends Controller
                 'card_brand'     => null,
                 'card_last_four' => null,
                 'trial_ends_at'  => null,
-                'stripe_id'      => null
+                'stripe_id'      => null,
             ])
                 ->save();
         }
@@ -87,7 +87,7 @@ class WebhookController extends Controller
     }
 
     /**
-     * Handle customer subscription updated
+     * Handle customer subscription updated.
      *
      * @param  array $payload
      * @return \Symfony\Component\HttpFoundation\Response
@@ -139,7 +139,7 @@ class WebhookController extends Controller
     }
 
     /**
-     * Handle customer updated
+     * Handle customer updated.
      *
      * @param  array $payload
      * @return \Symfony\Component\HttpFoundation\Response
@@ -163,7 +163,7 @@ class WebhookController extends Controller
                     if (isset($card['id']) && $card['id'] == $default_card) {
                         $user->forceFill([
                             'card_brand'     => $card['brand'] ?? null,
-                            'card_last_four' => $card['last4'] ?? null
+                            'card_last_four' => $card['last4'] ?? null,
                         ])
                             ->save();
                         break;

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -6,8 +6,8 @@ use Exception;
 use Illuminate\Http\Request;
 use Laravel\Cashier\Cashier;
 use Illuminate\Support\Carbon;
-use Laravel\Cashier\Subscription;
 use Stripe\Event as StripeEvent;
+use Laravel\Cashier\Subscription;
 use Illuminate\Routing\Controller;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -159,7 +159,7 @@ class WebhookController extends Controller
             )) {
                 $default_card = $data['default_source'];
                 foreach ($data['sources']['data'] as $card) {
-                    if (!isset($card['id']) || $card['id'] != $default_card) {
+                    if (! isset($card['id']) || $card['id'] != $default_card) {
                         continue;
                     }
                     $user->forceFill([

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -64,8 +64,8 @@ class WebhookController extends Controller
      */
     protected function handleCustomerDeleted(array $payload)
     {
-        $user = $this->getUserByStripeId($payload['data']['object']['id']);
         /* @var $user \App\User */
+        $user = $this->getUserByStripeId($payload['data']['object']['id']);
 
         if ($user) {
             $user->subscriptions->each(function ($subscription) {
@@ -79,8 +79,7 @@ class WebhookController extends Controller
                 'card_last_four' => null,
                 'trial_ends_at'  => null,
                 'stripe_id'      => null,
-            ])
-                ->save();
+            ])->save();
         }
 
         return new Response('Webhook Handled', 200);
@@ -94,8 +93,8 @@ class WebhookController extends Controller
      */
     protected function handleCustomerSubscriptionUpdated(array $payload)
     {
-        $user = $this->getUserByStripeId($payload['data']['object']['customer']);
         /* @var $user \App\User */
+        $user = $this->getUserByStripeId($payload['data']['object']['customer']);
         $data = $payload['data']['object'];
 
         if ($user) {
@@ -146,8 +145,8 @@ class WebhookController extends Controller
      */
     protected function handleCustomerUpdated(array $payload)
     {
-        $user = $this->getUserByStripeId($payload['data']['object']['id']);
         /* @var $user \App\User */
+        $user = $this->getUserByStripeId($payload['data']['object']['id']);
 
         if ($user) {
             $data = $payload['data']['object'];
@@ -160,14 +159,13 @@ class WebhookController extends Controller
             )) {
                 $default_card = $data['default_source'];
                 foreach ($data['sources']['data'] as $card) {
-                    if (isset($card['id']) && $card['id'] == $default_card) {
-                        $user->forceFill([
-                            'card_brand'     => $card['brand'] ?? null,
-                            'card_last_four' => $card['last4'] ?? null,
-                        ])
-                            ->save();
-                        break;
+                    if (!isset($card['id']) || $card['id'] != $default_card) {
+                        continue;
                     }
+                    $user->forceFill([
+                        'card_brand'     => $card['brand'] ?? null,
+                        'card_last_four' => $card['last4'] ?? null,
+                    ])->save();
                 }
             }
         }


### PR DESCRIPTION
Hi,

Since there are some data on the Cashier database, like "trial_ends_at"/"quantity"/"ends_at"/"card_last_four", ... , if something is done on the Stripe dashboard, the database must be updated to keep consistency.

This PR will handle some more webhooks than the customer.subscription.deleted provided by Cashier :

- **customer.deleted** : when a customer is deleted on the Stripe dashboard, all his subscriptions must be cancelled in Cashier and his card informations + his stripe_id must be emptied.

- **customer.subscription.updated** : when the quantity, the plan, the trial_end are updated on the Stripe dashboard, the database must be updated too.

- **customer.updated** : if the default card of a user is updated on the Stripe Dashboard, the card_brand & card_last_four have to be updated.

- **customer.source.deleted**: if the card of a user is deleted on the Stripe Dashboard, the card_brand & card_last_four have to be emptied.

Let me know if there are other webhooks to handle or if I misunderstood something !

Thanks

