### PR TITLE
[7.0] Bug solution for Issue #476

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -262,7 +262,10 @@ trait Billable
     public function findInvoice($id)
     {
         try {
-            return new Invoice($this, StripeInvoice::retrieve($id, $this->getStripeKey()));
+            $stripe_invoice = StripeInvoice::retrieve($id, $this->getStripeKey());
+            $stripe_lines = StripeInvoice::retrieve($id)->lines->all(array('limit'=>1000));
+            $stripe_invoice->lines = $stripe_lines;
+            return new Invoice($this, $stripe_invoice);
         } catch (Exception $e) {
             //
         }


### PR DESCRIPTION
Now retrieve an invoice with ALL line items:
As per Stripe API documentation, when retrieving an invoice, you only retrieve "the first handful of those items", referring to the line items. Currently, the "findInvoice" method of the Billable only retrieves the invoice without retrieving all the lines. Therefore, when bills are generated, we get lots of missing lines and therefore it's impossible to check by our customers if their bill is OK.

This pull request solves this problem by simply retrieving up to 1000 lines of the invoice and replacing the lines object of the original invoice.