### PR TITLE
[8.0] Revert changing subscription name on plan swap

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -232,10 +232,9 @@ class Subscription extends Model
      * Swap the subscription to a new Stripe plan.
      *
      * @param  string  $plan
-     * @param  string  $name
      * @return $this
      */
-    public function swap($plan, $name = null)
+    public function swap($plan)
     {
         $subscription = $this->asStripeSubscription();
 
@@ -267,16 +266,10 @@ class Subscription extends Model
 
         $this->user->invoice();
 
-        $attributes = [
-             'stripe_plan' => $plan,
-             'ends_at' => null,
-        ];
-
-        if ($name) {
-            $attributes['name'] = $name;
-        }
-
-        $this->fill($attributes)->save();
+        $this->fill([
+            'stripe_plan' => $plan,
+            'ends_at' => null,
+        ])->save();
 
         return $this;
     }

--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -122,12 +122,7 @@ class CashierTest extends TestCase
         $this->assertEquals(1, $subscription->quantity);
 
         // Swap Plan
-        $subscription->swap('monthly-10-2', 'premium');
-        $this->assertEquals('premium', $subscription->name);
-
-        // Rename Plan
-        $subscription->swap('monthly-10-2', 'main');
-        $this->assertEquals('main', $subscription->name);
+        $subscription->swap('monthly-10-2');
 
         $this->assertEquals('monthly-10-2', $subscription->stripe_plan);
 


### PR DESCRIPTION
This reverts https://github.com/laravel/cashier/pull/446

It doesn't really make sense to do this in the same operation. Swapping plans just means switching from one plan to the other. Changing the name of a subscription is just renaming it to a different context. Both have nothing to do with each other.

You can easily change the name of the subscription later on after the swap if you really want to. Changing this back keeps things more simple as well for swapping plans.

```php
$subscription = $subscription->swap(/* new plan */);

$subscription->name = 'new name';
$subscription->save();
```