### PR TITLE
[7.0] Bug solved: accessing the Stripe invoice lines with the Stripe Key. Issue #476 (#562)

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -266,7 +266,7 @@ trait Billable
                 $id, $this->getStripeKey()
             );
 
-            $stripeInvoice->lines = StripeInvoice::retrieve($id)
+            $stripeInvoice->lines = StripeInvoice::retrieve($id, $this->getStripeKey())
                         ->lines
                         ->all(['limit' => 1000]);
 


### PR DESCRIPTION
In our previous pull request, for the invoice lines, we requested to modify the Chasier. We normally access to Stripe by previously setting the stripe key so we don't need to provide it for each new access to Stripe:
`\Stripe\Stripe::setApiKey(env('STRIPE_SECRET'));`

 However, when making the request, we wanted to use the same method as you but we just now realised that by this way, the key is not set up for next access. So now we have included the Stripe key for the lines request to stripe:
`StripeInvoice::retrieve($id, $this->getStripeKey())`

Sorry for the inconvenience caused.