### PR TITLE
Add VerifyWebhookSignature middleware.

### DIFF
--- a/src/Http/Middleware/VerifyWebhookSignature.php
+++ b/src/Http/Middleware/VerifyWebhookSignature.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Laravel\Cashier\Http\Middleware;
+
+use Closure;
+use Stripe\Error\SignatureVerification;
+use Stripe\WebhookSignature;
+
+final class VerifyWebhookSignature
+{
+    public function handle($request, Closure $next)
+    {
+        try {
+            WebhookSignature::verifyHeader(
+                $request->getContent(),
+                $request->header('Stripe-Signature'),
+                config('services.stripe.webhook.secret'),
+                config('services.stripe.webhook.tolerance', 300)
+            );
+        } catch (SignatureVerification $exception) {
+            return abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/VerifyWebhookSignature.php
+++ b/src/Http/Middleware/VerifyWebhookSignature.php
@@ -15,7 +15,7 @@ final class VerifyWebhookSignature
                 $request->getContent(),
                 $request->header('Stripe-Signature'),
                 config('services.stripe.webhook.secret'),
-                config('services.stripe.webhook.tolerance', 300)
+                config('services.stripe.webhook.tolerance')
             );
         } catch (SignatureVerification $exception) {
             return abort(403);

--- a/src/Http/Middleware/VerifyWebhookSignature.php
+++ b/src/Http/Middleware/VerifyWebhookSignature.php
@@ -3,8 +3,8 @@
 namespace Laravel\Cashier\Http\Middleware;
 
 use Closure;
-use Stripe\Error\SignatureVerification;
 use Stripe\WebhookSignature;
+use Stripe\Error\SignatureVerification;
 
 final class VerifyWebhookSignature
 {

--- a/tests/VerifyWebhookSignatureTest.php
+++ b/tests/VerifyWebhookSignatureTest.php
@@ -13,7 +13,7 @@ final class VerifyWebhookSignatureTest extends PHPUnit_Framework_TestCase
     {
         $secret = 'secret';
 
-        config(['services.stripe.webhook.secret' => $secret]);
+        config(['services.stripe.webhook.secret' => $secret, 'services.stripe.webhook.tolerance' => 300]);
 
         $request = new Request([], [], [], [], [], [], 'Signed Body');
         $request->headers->set('Stripe-Signature', 't=' . time() . ',v1=' . $this->sign($request->getContent(), $secret));
@@ -36,7 +36,7 @@ final class VerifyWebhookSignatureTest extends PHPUnit_Framework_TestCase
     {
         $secret = 'secret';
 
-        config(['services.stripe.webhook.secret' => $secret]);
+        config(['services.stripe.webhook.secret' => $secret, 'services.stripe.webhook.tolerance' => 300]);
 
         $request = new Request([], [], [], [], [], [], 'Signed Body');
         $request->headers->set('Stripe-Signature', 't=' . time() . ',v1=fail');
@@ -50,7 +50,7 @@ final class VerifyWebhookSignatureTest extends PHPUnit_Framework_TestCase
     {
         $secret = 'secret';
 
-        config(['services.stripe.webhook.secret' => '']);
+        config(['services.stripe.webhook.secret' => '', 'services.stripe.webhook.tolerance' => 300]);
 
         $request = new Request([], [], [], [], [], [], 'Signed Body');
         $request->headers->set('Stripe-Signature', 't=' . time() . ',v1=' . $this->sign($request->getContent(), $secret));

--- a/tests/VerifyWebhookSignatureTest.php
+++ b/tests/VerifyWebhookSignatureTest.php
@@ -16,7 +16,7 @@ final class VerifyWebhookSignatureTest extends PHPUnit_Framework_TestCase
         config(['services.stripe.webhook.secret' => $secret, 'services.stripe.webhook.tolerance' => 300]);
 
         $request = new Request([], [], [], [], [], [], 'Signed Body');
-        $request->headers->set('Stripe-Signature', 't='.time().',v1=' . $this->sign($request->getContent(), $secret));
+        $request->headers->set('Stripe-Signature', 't='.time().',v1='.$this->sign($request->getContent(), $secret));
 
         $called = false;
 
@@ -43,7 +43,8 @@ final class VerifyWebhookSignatureTest extends PHPUnit_Framework_TestCase
 
         static::expectException(HttpException::class);
 
-        (new VerifyWebhookSignature)->handle($request, function ($request) {});
+        (new VerifyWebhookSignature)->handle($request, function ($request) {
+        });
     }
 
     public function test_no_secret_aborts()
@@ -53,7 +54,7 @@ final class VerifyWebhookSignatureTest extends PHPUnit_Framework_TestCase
         config(['services.stripe.webhook.secret' => '', 'services.stripe.webhook.tolerance' => 300]);
 
         $request = new Request([], [], [], [], [], [], 'Signed Body');
-        $request->headers->set('Stripe-Signature', 't='.time().',v1=' . $this->sign($request->getContent(), $secret));
+        $request->headers->set('Stripe-Signature', 't='.time().',v1='.$this->sign($request->getContent(), $secret));
 
         static::expectException(HttpException::class);
 

--- a/tests/VerifyWebhookSignatureTest.php
+++ b/tests/VerifyWebhookSignatureTest.php
@@ -3,9 +3,9 @@
 namespace Laravel\Cashier\Tests;
 
 use Illuminate\Http\Request;
-use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
 
 final class VerifyWebhookSignatureTest extends PHPUnit_Framework_TestCase
 {
@@ -16,7 +16,7 @@ final class VerifyWebhookSignatureTest extends PHPUnit_Framework_TestCase
         config(['services.stripe.webhook.secret' => $secret, 'services.stripe.webhook.tolerance' => 300]);
 
         $request = new Request([], [], [], [], [], [], 'Signed Body');
-        $request->headers->set('Stripe-Signature', 't=' . time() . ',v1=' . $this->sign($request->getContent(), $secret));
+        $request->headers->set('Stripe-Signature', 't='.time().',v1=' . $this->sign($request->getContent(), $secret));
 
         $called = false;
 
@@ -29,7 +29,7 @@ final class VerifyWebhookSignatureTest extends PHPUnit_Framework_TestCase
 
     private function sign($payload, $secret)
     {
-        return hash_hmac("sha256", $payload, $secret);
+        return hash_hmac('sha256', $payload, $secret);
     }
 
     public function test_bad_signature_aborts()
@@ -39,7 +39,7 @@ final class VerifyWebhookSignatureTest extends PHPUnit_Framework_TestCase
         config(['services.stripe.webhook.secret' => $secret, 'services.stripe.webhook.tolerance' => 300]);
 
         $request = new Request([], [], [], [], [], [], 'Signed Body');
-        $request->headers->set('Stripe-Signature', 't=' . time() . ',v1=fail');
+        $request->headers->set('Stripe-Signature', 't='.time().',v1=fail');
 
         static::expectException(HttpException::class);
 
@@ -53,10 +53,11 @@ final class VerifyWebhookSignatureTest extends PHPUnit_Framework_TestCase
         config(['services.stripe.webhook.secret' => '', 'services.stripe.webhook.tolerance' => 300]);
 
         $request = new Request([], [], [], [], [], [], 'Signed Body');
-        $request->headers->set('Stripe-Signature', 't=' . time() . ',v1=' . $this->sign($request->getContent(), $secret));
+        $request->headers->set('Stripe-Signature', 't='.time().',v1=' . $this->sign($request->getContent(), $secret));
 
         static::expectException(HttpException::class);
 
-        (new VerifyWebhookSignature)->handle($request, function ($request) {});
+        (new VerifyWebhookSignature)->handle($request, function ($request) {
+        });
     }
 }

--- a/tests/VerifyWebhookSignatureTest.php
+++ b/tests/VerifyWebhookSignatureTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Laravel\Cashier\Tests;
+
+use Illuminate\Http\Request;
+use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class VerifyWebhookSignatureTest extends PHPUnit_Framework_TestCase
+{
+    public function test_signature_checks_out()
+    {
+        $secret = 'secret';
+
+        config(['services.stripe.webhook.secret' => $secret]);
+
+        $request = new Request([], [], [], [], [], [], 'Signed Body');
+        $request->headers->set('Stripe-Signature', 't=' . time() . ',v1=' . $this->sign($request->getContent(), $secret));
+
+        $called = false;
+
+        (new VerifyWebhookSignature)->handle($request, function ($request) use (&$called) {
+            $called = true;
+        });
+
+        static::assertTrue($called);
+    }
+
+    private function sign($payload, $secret)
+    {
+        return hash_hmac("sha256", $payload, $secret);
+    }
+
+    public function test_bad_signature_aborts()
+    {
+        $secret = 'secret';
+
+        config(['services.stripe.webhook.secret' => $secret]);
+
+        $request = new Request([], [], [], [], [], [], 'Signed Body');
+        $request->headers->set('Stripe-Signature', 't=' . time() . ',v1=fail');
+
+        static::expectException(HttpException::class);
+
+        (new VerifyWebhookSignature)->handle($request, function ($request) {});
+    }
+
+    public function test_no_secret_aborts()
+    {
+        $secret = 'secret';
+
+        config(['services.stripe.webhook.secret' => '']);
+
+        $request = new Request([], [], [], [], [], [], 'Signed Body');
+        $request->headers->set('Stripe-Signature', 't=' . time() . ',v1=' . $this->sign($request->getContent(), $secret));
+
+        static::expectException(HttpException::class);
+
+        (new VerifyWebhookSignature)->handle($request, function ($request) {});
+    }
+}


### PR DESCRIPTION
This PR addresses #437.

A few notes on this PR:

- The configuration keys are assumed to exist, as they add on to the keys already defined in `services.php` in Laravel proper. Assuming this gets merged, those keys will eventually need to be added to that configuration file.
  - There should be a default value set for the tolerance. [Stripe's default tolerance](https://stripe.com/docs/webhooks/signatures#replay-attacks) is `300` and seems a reasonable default.
- The middleware intentionally fails closed. If the user enables this middleware without a web-hook key set, we can assume that the user wants to enforce signatures and that the lack of a key is unintentional.