### PR TITLE
[7.0] Add updateTax method to sync tax to subscription

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -380,6 +380,20 @@ class Subscription extends Model
     }
 
     /**
+     * Syncs the tax percentage of user to the subscription.
+     *
+     * @return void
+     */
+    public function updateTax()
+    {
+        $subscription = $this->asStripeSubscription();
+
+        $subscription->tax_percent = $this->user->taxPercentage();
+
+        $subscription->save();
+    }
+
+    /**
      * Get the subscription as a Stripe subscription object.
      *
      * @return \Stripe\Subscription


### PR DESCRIPTION
When the tax for a billable model changes it needs to be updated on its active subscription as well. This method provides an easy and convenient way to sync the billable model's tax to the subscription.

If this gets merged, I'll send in a PR to the docs as well to document this.

Background: there was a pretty large and longtime issue about tax changes not being applied to subscriptions https://github.com/laravel/cashier/issues/384. Turns out that Stripe subscriptions keep the original tax applied to them when you change the hardcoded value in `taxPercentage` on the billable user. What needs to happen is that users need to sync this change on their subscriptions if they want this tax change applied to their subscription. Otherwise Stripe will continue to use the old tax percentage value.

This can also happen when for example, a customer's billing details change and their country of residence changes and thus their tax rate changes. 

This added method provides a convenient way to call a single method to update a subscription's tax percentage from its billable model. 