### PR TITLE
[7.0] Bug solution: Invoice template suggestion of change

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -112,72 +112,72 @@
                 @endif
 
                 <br><br>
-
-                <!-- Invoice Table -->
-                <table width="100%" class="table" border="0">
-                    <tr>
-                        <th align="left">Description</th>
-                        <th align="right">Date</th>
-                        <th align="right">Amount</th>
-                    </tr>
-
-                    <!-- Existing Balance -->
-                    <tr>
-                        <td>Starting Balance</td>
-                        <td>&nbsp;</td>
-                        <td>{{ $invoice->startingBalance() }}</td>
-                    </tr>
-
-                    <!-- Display The Invoice Items -->
-                    @foreach ($invoice->invoiceItems() as $item)
-                        <tr>
-                            <td colspan="2">{{ $item->description }}</td>
-                            <td>{{ $item->total() }}</td>
-                        </tr>
-                    @endforeach
-
-                    <!-- Display The Subscriptions -->
-                    @foreach ($invoice->subscriptions() as $subscription)
-                        <tr>
-                            <td>Subscription ({{ $subscription->quantity }})</td>
-                            <td>
-                                {{ $subscription->startDateAsCarbon()->formatLocalized('%B %e, %Y') }} -
-                                {{ $subscription->endDateAsCarbon()->formatLocalized('%B %e, %Y') }}
-                            </td>
-                            <td>{{ $subscription->total() }}</td>
-                        </tr>
-                    @endforeach
-
-                    <!-- Display The Discount -->
-                    @if ($invoice->hasDiscount())
-                        <tr>
-                            @if ($invoice->discountIsPercentage())
-                                <td>{{ $invoice->coupon() }} ({{ $invoice->percentOff() }}% Off)</td>
-                            @else
-                                <td>{{ $invoice->coupon() }} ({{ $invoice->amountOff() }} Off)</td>
-                            @endif
-                            <td>&nbsp;</td>
-                            <td>-{{ $invoice->discount() }}</td>
-                        </tr>
-                    @endif
-
-                    <!-- Display The Tax Amount -->
-                    @if ($invoice->tax_percent)
-                        <tr>
-                            <td>Tax ({{ $invoice->tax_percent }}%)</td>
-                            <td>&nbsp;</td>
-                            <td>{{ Laravel\Cashier\Cashier::formatAmount($invoice->tax) }}</td>
-                        </tr>
-                    @endif
-
-                    <!-- Display The Final Total -->
-                    <tr style="border-top:2px solid #000;">
-                        <td>&nbsp;</td>
-                        <td style="text-align: right;"><strong>Total</strong></td>
-                        <td><strong>{{ $invoice->total() }}</strong></td>
-                    </tr>
-                </table>
             </td>
+        </tr>
+    </table>
+
+    <!-- Invoice Table -->
+    <table width="100%" class="table" border="0">
+        <tr>
+            <th align="left">Description</th>
+            <th align="right">Date</th>
+            <th align="right">Amount</th>
+        </tr>
+
+        <!-- Existing Balance -->
+        <tr>
+            <td>Starting Balance</td>
+            <td>&nbsp;</td>
+            <td>{{ $invoice->startingBalance() }}</td>
+        </tr>
+
+        <!-- Display The Invoice Items -->
+        @foreach ($invoice->invoiceItems() as $item)
+            <tr>
+                <td colspan="2">{{ $item->description }}</td>
+                <td>{{ $item->total() }}</td>
+            </tr>
+        @endforeach
+
+    <!-- Display The Subscriptions -->
+        @foreach ($invoice->subscriptions() as $subscription)
+            <tr>
+                <td>Subscription ({{ $subscription->quantity }})</td>
+                <td>
+                    {{ $subscription->startDateAsCarbon()->formatLocalized('%B %e, %Y') }} -
+                    {{ $subscription->endDateAsCarbon()->formatLocalized('%B %e, %Y') }}
+                </td>
+                <td>{{ $subscription->total() }}</td>
+            </tr>
+        @endforeach
+
+    <!-- Display The Discount -->
+        @if ($invoice->hasDiscount())
+            <tr>
+                @if ($invoice->discountIsPercentage())
+                    <td>{{ $invoice->coupon() }} ({{ $invoice->percentOff() }}% Off)</td>
+                @else
+                    <td>{{ $invoice->coupon() }} ({{ $invoice->amountOff() }} Off)</td>
+                @endif
+                <td>&nbsp;</td>
+                <td>-{{ $invoice->discount() }}</td>
+            </tr>
+        @endif
+
+    <!-- Display The Tax Amount -->
+        @if ($invoice->tax_percent)
+            <tr>
+                <td>Tax ({{ $invoice->tax_percent }}%)</td>
+                <td>&nbsp;</td>
+                <td>{{ Laravel\Cashier\Cashier::formatAmount($invoice->tax) }}</td>
+            </tr>
+    @endif
+
+    <!-- Display The Final Total -->
+        <tr style="border-top:2px solid #000;">
+            <td>&nbsp;</td>
+            <td style="text-align: right;"><strong>Total</strong></td>
+            <td><strong>{{ $invoice->total() }}</strong></td>
         </tr>
     </table>
 </div>


### PR DESCRIPTION
We have our own template for the invoices. However, regarding our last Pull request #564, we just realized that if you are using the template from the cashier (receipt.blade.php), when the number of lines exceeds the page size, there is a problem of visualization. This is because the entire "Invoice table" is within a single row of the general table of the document. So we just moved the entire invoice table outside the row.

We suggest this very simple change in the template for the users that are using the provided template for the invoice in the cashier. This is only a suggestion, as mentioned, we are using our own template. We have checked the result of this template and we like it because the Invoice table is much wider, taking profit of the whole page width. So now there is much more space for the "Description" column and for the "Date", wherein our case sometimes they were overlapped.

Be aware that this change will affect not only invoices with a lot of lines but also the rest of them. But apart from solving the problem for long invoices, we like this design, much spaced.