### PR TITLE
[8.0] Update to v6 of the Stripe SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/database": "~5.3",
         "illuminate/support": "~5.3",
         "nesbot/carbon": "~1.0",
-        "stripe/stripe-php": "~5.0",
+        "stripe/stripe-php": "~6.0",
         "symfony/http-kernel": "~2.7|~3.0|~4.0"
     },
     "require-dev": {


### PR DESCRIPTION
The [list of breaking changes](https://github.com/stripe/stripe-php/blob/master/CHANGELOG.md#600---2018-02-07) doesn't seem to impact this library.

The tests pass when I run them locally after this change, although it doesn't seem like the tests run on travis for this repo.