### PR TITLE
Make sure to reactivate subscription when swapping plans

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -253,7 +253,7 @@ class Subscription extends Model
         $subscription->plan = $plan;
 
         $subscription->prorate = $this->prorate;
-        
+
         $subscription->cancel_at_period_end = false;
 
         if (! is_null($this->billingCycleAnchor)) {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -253,6 +253,8 @@ class Subscription extends Model
         $subscription->plan = $plan;
 
         $subscription->prorate = $this->prorate;
+        
+        $subscription->cancel_at_period_end = false;
 
         if (! is_null($this->billingCycleAnchor)) {
             $subscription->billing_cycle_anchor = $this->billingCycleAnchor;


### PR DESCRIPTION
When a user has a cancelled subscription, and within a UI, swaps his plan selection, we must make sure to reactivate the subscription, otherwise Cashier will take into account that the user has a "valid subscription", and the Stripe webhook that comes a few seconds later will immediately re-cancel the plan.

Adding `$subscription->cancel_at_period_end = false;` makes sure the plan is reactivated.