### PR TITLE
[8.0] Make sure to reactivate subscription when swapping plans

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -254,6 +254,9 @@ class Subscription extends Model
 
         $subscription->prorate = $this->prorate;
 
+        // Let's make sure the subscription is resumed if the subscription was cancelled
+        $subscription->cancel_at_period_end = false;
+
         if (! is_null($this->billingCycleAnchor)) {
             $subscription->billing_cycle_anchor = $this->billingCycleAnchor;
         }


### PR DESCRIPTION
When a user has a cancelled subscription, and within a UI, swaps his plan selection, we must make sure to reactivate the subscription, otherwise, Cashier will take into account that the user has a "valid subscription", and the Stripe webhook that comes a few seconds later will immediately re-cancel the plan.

Adding `$subscription->cancel_at_period_end = false;` makes sure the plan is reactivated.