### PR TITLE
[9.0] Do not update card in createAsStripeCustomer method

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,11 @@
 # Cashier Change Log
 
+## Unreleased
+
+### Changed
+
+- Extract `updateCard` from `createAsStripeCustomer` method ([#588](https://github.com/laravel/cashier/pull/588))
+
 ## Version 2.0.4
 
 - Allow user to pass paramaters when fetching invoices.

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -546,14 +546,14 @@ trait Billable
     /**
      * Create a Stripe customer for the given Stripe model.
      *
-     * @param  string  $token
      * @param  array  $options
      * @return \Stripe\Customer
      */
-    public function createAsStripeCustomer($token, array $options = [])
+    public function createAsStripeCustomer(array $options = [])
     {
         $options = array_key_exists('email', $options)
-                ? $options : array_merge($options, ['email' => $this->email]);
+                ? $options
+                : array_merge($options, ['email' => $this->email]);
 
         // Here we will create the customer instance on Stripe and store the ID of the
         // user from Stripe. This ID will correspond with the Stripe user instances
@@ -565,13 +565,6 @@ trait Billable
         $this->stripe_id = $customer->id;
 
         $this->save();
-
-        // Next we will add the credit card to the user's account on Stripe using this
-        // token that was provided to this method. This will allow us to bill users
-        // when they subscribe to plans or we need to do one-off charges on them.
-        if (! is_null($token)) {
-            $this->updateCard($token);
-        }
 
         return $customer;
     }

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -228,14 +228,14 @@ class SubscriptionBuilder
      */
     protected function getStripeCustomer($token = null, array $options = [])
     {
-        if (! $this->owner->stripe_id) {
-            $customer = $this->owner->createAsStripeCustomer($token, $options);
-        } else {
+        if ($this->owner->stripe_id) {
             $customer = $this->owner->asStripeCustomer();
+        } else {
+            $customer = $this->owner->createAsStripeCustomer($options);
+        }
 
-            if ($token) {
-                $this->owner->updateCard($token);
-            }
+        if ($token) {
+            $this->owner->updateCard($token);
         }
 
         return $customer;

--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -358,7 +358,8 @@ class CashierTest extends TestCase
         ]);
 
         // Create Invoice
-        $user->createAsStripeCustomer($this->getTestToken());
+        $user->createAsStripeCustomer();
+        $user->updateCard($this->getTestToken());
         $user->invoiceFor('Laravel Cashier', 1000);
 
         // Invoice Tests
@@ -375,7 +376,8 @@ class CashierTest extends TestCase
         ]);
 
         // Create Invoice
-        $user->createAsStripeCustomer($this->getTestToken());
+        $user->createAsStripeCustomer();
+        $user->updateCard($this->getTestToken());
         $invoice = $user->invoiceFor('Laravel Cashier', 1000);
 
         // Create the refund


### PR DESCRIPTION
At the moment when using the `createAsStripeCustomer` method on a `Billable` entity, it could be that the creation of the customer succeeds but the updating of the card fails. When this happens it's impossible to know which customer was created in Stripe and therefor also impossible to remove this record again when the card update fails.

It seems that the `updateCard` method shouldn't be in the `createAsStripeCustomer` method as this couples these two API calls too much. If we remove the call from the `createAsStripeCustomer` method it can be used just for the purpose that it states. This will always return a `Customer` object and allow the developer to remove it again if the `updateCard` method after that fails.

This is a breaking change which will require developers to call the `updateCard` method manually after they call `createAsStripeCustomer`. I've already adjusted the behavior of the `getStripeCustomer` call in the `SubscriptionBuilder` so there's no breaking changes there.

You might notice that at the moment the same problem exists for the `getStripeCustomer` call but at least with these changes the developers have full control to first create the customer and then do a try/catch check around the `updateCard` method and revert the customer creation if they want.

This will require changes to the docs as well which I'll send in as soon as this PR is merged.

Fixes https://github.com/laravel/cashier/issues/575