### PR TITLE
[8.0] Remove dotenv library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "illuminate/routing": "~5.3",
         "illuminate/view": "~5.3",
         "mockery/mockery": "~1.0",
-        "phpunit/phpunit": "~6.0",
-        "vlucas/phpdotenv": "~2.0"
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ You will need to set the following details locally and on your Stripe account in
 
 ### Environment
 
-#### .env
+#### Environment Variables
 
     STRIPE_SECRET=
     STRIPE_MODEL=Laravel\Cashier\Tests\Fixtures\User

--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -12,14 +12,6 @@ use Laravel\Cashier\Tests\Fixtures\CashierTestControllerStub;
 
 class CashierTest extends TestCase
 {
-    public static function setUpBeforeClass()
-    {
-        if (file_exists(__DIR__.'/../.env')) {
-            $dotenv = new \Dotenv\Dotenv(__DIR__.'/../');
-            $dotenv->load();
-        }
-    }
-
     public function setUp()
     {
         Eloquent::unguard();


### PR DESCRIPTION
This isn't needed anymore as the environment variables are loaded through the PHPUnit config file.