### PR TITLE
[9.0] Encourage usage of VerifyWebhookSignature middleware

### DIFF
--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -410,8 +410,8 @@ class User extends Eloquent
 
 class CashierTestControllerStub extends WebhookController
 {
-    protected function eventExistsOnStripe($id)
+    public function __construct()
     {
-        return true;
+        // Prevent setting middleware...
     }
 }

--- a/tests/WebhookControllerTest.php
+++ b/tests/WebhookControllerTest.php
@@ -29,13 +29,13 @@ class WebhookControllerTest extends TestCase
 
 class WebhookControllerTestStub extends WebhookController
 {
+    public function __construct()
+    {
+        // Prevent setting middleware...
+    }
+
     public function handleChargeSucceeded()
     {
         $_SERVER['__received'] = true;
-    }
-
-    protected function eventExistsOnStripe($id)
-    {
-        return true;
     }
 }


### PR DESCRIPTION
This PR changes the way we check for events. It removes the API calls to Stripe for checking if an event exists and encourages the usage of the VerifyWebhookSignature middleware.

Verifying incoming webhook events by their signature is the recommended way by Stripe for making sure the event is legit. Making an API call to Stripe like we do now is a bit irrelevant as we can totally verify the legitemacy of the event by the signature alone. This saves us extra API calls to Stripe and should actually speed up webhooks.

This also solves the problem of the CASHIER_ENV env variable. Now that the middleware is only set on the controller when the webhook secret is filled in you have total control of turning it on and off for your use case.

The docs should be updated a little bit to encourage people setting the webhook secret immediately when working with webhooks. It's also not recommended anymore to set the middleware on the route as it's already been set on the controller itself.

All in all this commit simplifies things a lot and solves quite a few things together. It's breaking so I'm targeting master. I'll update the change log as soon as this gets merged. We should encourage people to read it before upgrading.

Fixes https://github.com/laravel/cashier/issues/537