### PR TITLE
[9.0] Require ext-json for json_ function calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^7.1.3",
+        "ext-json": "*",
         "dompdf/dompdf": "^0.8.0",
         "illuminate/database": "~5.7",
         "illuminate/support": "~5.7",


### PR DESCRIPTION
Before:

![screen shot 2018-12-13 at 1 45 45 pm](https://user-images.githubusercontent.com/594614/49939540-6f19f600-fedd-11e8-8578-085e3db5be48.png)

After:

![screen shot 2018-12-13 at 1 42 27 pm](https://user-images.githubusercontent.com/594614/49939495-501b6400-fedd-11e8-8fab-8e2f700629eb.png)
