### PR TITLE
[9.0] Bump dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/composer.json
+++ b/composer.json
@@ -14,20 +14,20 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1.3",
         "dompdf/dompdf": "^0.8.0",
-        "illuminate/database": "~5.3",
-        "illuminate/support": "~5.3",
+        "illuminate/database": "~5.7",
+        "illuminate/support": "~5.7",
         "nesbot/carbon": "~1.0",
         "stripe/stripe-php": "~6.0",
-        "symfony/http-kernel": "~2.7|~3.0|~4.0"
+        "symfony/http-kernel": "~4.0"
     },
     "require-dev": {
-        "illuminate/http": "~5.3",
-        "illuminate/routing": "~5.3",
-        "illuminate/view": "~5.3",
+        "illuminate/http": "~5.7",
+        "illuminate/routing": "~5.7",
+        "illuminate/view": "~5.7",
         "mockery/mockery": "~1.0",
-        "phpunit/phpunit": "~6.0"
+        "phpunit/phpunit": "~7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -19,14 +19,4 @@ class CashierServiceProvider extends ServiceProvider
             __DIR__.'/../resources/views' => $this->app->basePath('resources/views/vendor/cashier'),
         ]);
     }
-
-    /**
-     * Register the service provider.
-     *
-     * @return void
-     */
-    public function register()
-    {
-        //
-    }
 }


### PR DESCRIPTION
Bumped dependencies to the minimum framework supported components and current supported PHP version of the framework. Also removed support for Symfony HttpKernel <4.0 since the framework itself doesn't supports it anymore.