### PR TITLE
[9.0] Fix invoicing subscriptions and extend one off charges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@
 - Require Laravel 5.7 as minimum version ([#595](https://github.com/laravel/cashier/pull/595))
 - Extract `updateCard` from `createAsStripeCustomer` method ([#588](https://github.com/laravel/cashier/pull/588))
 - Remove `CASHIER_ENV` and event checks and encourage usage of `VerifyWebhookSignature` middleware ([#591](https://github.com/laravel/cashier/pull/591))
+- The `invoice` method now accepts an `$options` param ([#598](https://github.com/laravel/cashier/pull/598))
+- The `invoiceFor` method now accepts an `$invoiceOptions` param ([#598](https://github.com/laravel/cashier/pull/598))
 
 ### Fixed
 
 - Fixed some DocBlocks ([#594](https://github.com/laravel/cashier/pull/594))
+- Fixed a bug where the `swap` and `incrementAndInvoice` methods on the `Subscription` model would sometimes invoice other pending invoice items ([#598](https://github.com/laravel/cashier/pull/598))
 
 ## Version 2.0.4
 

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -587,7 +587,7 @@ trait Billable
     /**
      * Get the tax percentage to apply to the subscription.
      *
-     * @return int
+     * @return int|float
      */
     public function taxPercentage()
     {

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -32,7 +32,6 @@ trait Billable
      * @param  int  $amount
      * @param  array  $options
      * @return \Stripe\Charge
-     *
      * @throws \InvalidArgumentException
      */
     public function charge($amount, array $options = [])
@@ -215,13 +214,16 @@ trait Billable
     /**
      * Invoice the billable entity outside of regular billing cycle.
      *
+     * @param  array  $options
      * @return \Stripe\Invoice|bool
      */
-    public function invoice()
+    public function invoice(array $options = [])
     {
         if ($this->stripe_id) {
+            $parameters = array_merge($options, ['customer' => $this->stripe_id]);
+
             try {
-                return StripeInvoice::create(['customer' => $this->stripe_id], $this->getStripeKey())->pay();
+                return StripeInvoice::create($parameters, $this->getStripeKey())->pay();
             } catch (StripeErrorInvalidRequest $e) {
                 return false;
             }

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -108,14 +108,15 @@ trait Billable
      *
      * @param  string  $description
      * @param  int  $amount
-     * @param  array  $options
+     * @param  array  $tabOptions
+     * @param  array  $invoiceOptions
      * @return \Laravel\Cashier\Invoice|bool
      */
-    public function invoiceFor($description, $amount, array $options = [])
+    public function invoiceFor($description, $amount, array $tabOptions = [], array $invoiceOptions = [])
     {
-        $this->tab($description, $amount, $options);
+        $this->tab($description, $amount, $tabOptions);
 
-        return $this->invoice();
+        return $this->invoice($invoiceOptions);
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -155,7 +155,7 @@ class Subscription extends Model
     {
         $this->incrementQuantity($count);
 
-        $this->user->invoice();
+        $this->user->invoice(['subscription' => $this->stripe_id]);
 
         return $this;
     }
@@ -278,7 +278,7 @@ class Subscription extends Model
 
         $subscription->save();
 
-        $this->user->invoice();
+        $this->user->invoice(['subscription' => $subscription->id]);
 
         $this->fill([
             'stripe_plan' => $plan,

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -278,7 +278,7 @@ class SubscriptionBuilder
     /**
      * Get the tax percentage for the Stripe payload.
      *
-     * @return int|null
+     * @return int|float|null
      */
     protected function getTaxPercentageForPayload()
     {


### PR DESCRIPTION
I sent this PR with 2 changes because the 2nd one depends on the first one. Here's the commit summary for both:

When invoicing the customer while swapping plans, Cashier would invoice the customer for all its pending items instead of just the ones for the subscription. This PR fixes this by using the subscription field when creating an invoice to allow swapping a plan and the `incrementAndInvoice` method so the invoice at hand only invoices for the subscription and also uses the proper tax which is applied to the subscription.

When doing one off charges and immediately invoicing them you currently can't add extra options like a tax_percent to it which kind of limits you. By adding this extra option we can pass it to the invoice method with the parameter from the previous commit.

Fixes https://github.com/laravel/cashier/issues/384