### PR TITLE
Correct PHP Doc @return tag

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -110,7 +110,7 @@ trait Billable
      * @param  int  $amount
      * @param  array  $tabOptions
      * @param  array  $invoiceOptions
-     * @return \Laravel\Cashier\Invoice|bool
+     * @return \Stripe\Invoice|bool
      */
     public function invoiceFor($description, $amount, array $tabOptions = [], array $invoiceOptions = [])
     {


### PR DESCRIPTION
$this->invoice returns a Stripe invoice object, and thus $invoiceFor too.