### PR TITLE
[9.0] Allow Carbon 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "dompdf/dompdf": "^0.8.0",
         "illuminate/database": "~5.7",
         "illuminate/support": "~5.7",
-        "nesbot/carbon": "~1.0",
+        "nesbot/carbon": "~1.0 || ~2.0",
         "stripe/stripe-php": "~6.0",
         "symfony/http-kernel": "~4.0"
     },


### PR DESCRIPTION
This will allow CarbonImmutable and all features added in Carbon 2 and so use the default version from Laravel 5.8.