### PR TITLE
[9.0] Add subscription state scopes

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -83,6 +83,19 @@ class Subscription extends Model
     }
 
     /**
+     * Filter query by active.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    public function scopeActive($query)
+    {
+        $query->whereNull('ends_at')->orWhere(function ($query) {
+            $query->onGracePeriod();
+        });
+    }
+
+    /**
      * Determine if the subscription is recurring and not on trial.
      *
      * @return bool
@@ -90,6 +103,17 @@ class Subscription extends Model
     public function recurring()
     {
         return ! $this->onTrial() && ! $this->cancelled();
+    }
+
+    /**
+     * Filter query by recurring.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    public function scopeRecurring($query)
+    {
+        $query->notOnTrial()->notCancelled();
     }
 
     /**
@@ -103,6 +127,28 @@ class Subscription extends Model
     }
 
     /**
+     * Filter query by cancelled.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    public function scopeCancelled($query)
+    {
+        $query->whereNotNull('ends_at');
+    }
+
+    /**
+     * Filter query by not cancelled.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    public function scopeNotCancelled($query)
+    {
+        $query->whereNull('ends_at');
+    }
+
+    /**
      * Determine if the subscription has ended and the grace period has expired.
      *
      * @return bool
@@ -110,6 +156,17 @@ class Subscription extends Model
     public function ended()
     {
         return $this->cancelled() && ! $this->onGracePeriod();
+    }
+
+    /**
+     * Filter query by ended.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    public function scopeEnded($query)
+    {
+        $query->cancelled()->notOnGracePeriod();
     }
 
     /**
@@ -123,6 +180,28 @@ class Subscription extends Model
     }
 
     /**
+     * Filter query by on trial.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    public function scopeOnTrial($query)
+    {
+        $query->whereNotNull('trial_ends_at')->where('trial_ends_at', '>', Carbon::now());
+    }
+
+    /**
+     * Filter query by not on trial.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    public function scopeNotOnTrial($query)
+    {
+        $query->whereNull('trial_ends_at')->orWhere('trial_ends_at', '<=', Carbon::now());
+    }
+
+    /**
      * Determine if the subscription is within its grace period after cancellation.
      *
      * @return bool
@@ -130,6 +209,28 @@ class Subscription extends Model
     public function onGracePeriod()
     {
         return $this->ends_at && $this->ends_at->isFuture();
+    }
+
+    /**
+     * Filter query by on grace period.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    public function scopeOnGracePeriod($query)
+    {
+        $query->whereNotNull('ends_at')->where('ends_at', '>', Carbon::now());
+    }
+
+    /**
+     * Filter query by not on grace period.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return void
+     */
+    public function scopeNotOnGracePeriod($query)
+    {
+        $query->whereNull('ends_at')->orWhere('ends_at', '<=', Carbon::now());
     }
 
     /**


### PR DESCRIPTION
I've been using these in my applications and I had someone else ask about them, so I thought I would PR them and see if they might be handy having in the base package.

You can now apply query scopes based on the state of the subscription.

## On trial

```php
$users = User::whereHas('subscriptions', function ($query) {
    $query->whereName('gold')->onTrial();
})->get();
```

## Active

```php
$users = User::whereHas('subscriptions', function ($query) {
    $query->whereName('gold')->active();
})->get();
```

## Cancelled

```php
$users = User::whereHas('subscriptions', function ($query) {
    $query->whereName('gold')->cancelled();
})->get();
```

## On grace period

```php
$users = User::whereHas('subscriptions', function ($query) {
    $query->whereName('gold')->onGracePeriod();
})->get();
```

## Ended

```php
$users = User::whereHas('subscriptions', function ($query) {
    $query->whereName('gold')->ended();
})->get();
```

## Recurring

```php
$users = User::whereHas('subscriptions', function ($query) {
    $query->whereName('gold')->recurring();
})->get();
```

There are a couple of other added scopes, but they are just there to let these 👆ones work nicely under the hood.

These can come in handy when you want to email all your subscribers that perhaps have cancelled - or send a thank you for all your recurring subscribers once a year, etc.

```php

// These users signed up and didn't even finish the trial before they cancelled.
// We might wanna reach out and see if they had any issues with the service.

$users = User::whereHas('subscriptions', function ($query) {
    $query->whereName('gold')->onTrial()->cancelled();
})->get();
```

As [pointed out on Twitter](https://twitter.com/TaylorGoodallAU/status/1098019865527341057) this would also be handy for reporting.