### PR TITLE
[10.0] Do not clear trial_ends_at value to NULL

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -159,7 +159,6 @@ class WebhookController extends Controller
 
             $user->forceFill([
                 'stripe_id' => null,
-                'trial_ends_at' => null,
                 'card_brand' => null,
                 'card_last_four' => null,
             ])->save();


### PR DESCRIPTION
Clearing an existing `trial_ends_at` value to NULL breaks the user's "generic" trial period.

