### PR TITLE
[9.0] Update invoice date method to work with latest '2019-03-14' stripe api.

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -45,7 +45,7 @@ class Invoice
      */
     public function date($timezone = null)
     {
-        $carbon = Carbon::createFromTimestampUTC($this->invoice->date);
+        $carbon = Carbon::createFromTimestampUTC($this->invoice->created);
 
         return $timezone ? $carbon->setTimezone($timezone) : $carbon;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,6 +9,6 @@ abstract class TestCase extends BaseTestCase
 {
     protected function setUp()
     {
-        Stripe::setApiVersion('2019-02-19');
+        Stripe::setApiVersion('2019-03-14');
     }
 }


### PR DESCRIPTION
Hello, stripe have updated their api. The date method on the invoice fails, because they have renamed `date` field to `created`. 

I have amended the date method to use this `created` field. 