### PR TITLE
[10.0] Add options to subscription swap

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ You can set these variables in the `phpunit.xml` file.
 
 #### Coupons
 
-    * coupon-1 ($5)
+    * coupon-1 ($5) (Duration longer than once)
 
 ## Contributing
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -345,9 +345,10 @@ class Subscription extends Model
      * Swap the subscription to a new Stripe plan.
      *
      * @param  string  $plan
+     * @param  array  $options
      * @return $this
      */
-    public function swap($plan)
+    public function swap($plan, $options = [])
     {
         $subscription = $this->asStripeSubscription();
 
@@ -359,6 +360,10 @@ class Subscription extends Model
 
         if (! is_null($this->billingCycleAnchor)) {
             $subscription->billing_cycle_anchor = $this->billingCycleAnchor;
+        }
+
+        foreach ($options as $key => $option) {
+            $subscription->$key = $option;
         }
 
         // If no specific trial end date has been set, the default behavior should be

--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -139,6 +139,24 @@ class CashierTest extends TestCase
         $this->assertInstanceOf(Carbon::class, $invoice->date());
     }
 
+    public function test_swapping_subscription_with_coupon()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        $user->newSubscription('main', 'monthly-10-1')->create($this->getTestToken());
+        $subscription = $user->subscription('main');
+
+        // Swap Plan with Coupon
+        $subscription->swap('monthly-10-2', [
+            'coupon' => 'coupon-1',
+        ]);
+
+        $this->assertEquals('coupon-1', $subscription->asStripeSubscription()->discount->coupon->id);
+    }
+
     public function test_creating_subscription_with_coupons()
     {
         $user = User::create([


### PR DESCRIPTION
This resolves #580 - you can now pass in parameters when swapping a subscription, such as a coupon.

I believe this would also resolve #550, but I haven't tested it.

Pull request to the master branch.