### PR TITLE
[9.0] Handle subscription reactivation webhook

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -79,10 +79,14 @@ class WebhookController extends Controller
                 }
 
                 // Cancellation date...
-                if (isset($data['cancel_at_period_end']) && $data['cancel_at_period_end']) {
-                    $subscription->ends_at = $subscription->onTrial()
-                                ? $subscription->trial_ends_at
-                                : Carbon::createFromTimestamp($data['current_period_end']);
+                if (isset($data['cancel_at_period_end'])) {
+                    if ($data['cancel_at_period_end']) {
+                        $subscription->ends_at = $subscription->onTrial()
+                            ? $subscription->trial_ends_at
+                            : Carbon::createFromTimestamp($data['current_period_end']);
+                    } else {
+                        $subscription->ends_at = null;
+                    }
                 }
 
                 $subscription->save();


### PR DESCRIPTION
Hey,

I missed something  with my pull request in order to handle more webhooks (#561), the reactivation of a cancelled subscription that is in grace period.
There is a "**customer.subscription.updated**" event called with a _cancel_at_period_end_ set to _false_

Without this change, the _ends_at_ column still to the cancellation date.

Thanks !