### PR TITLE
[9.0] Update testing instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Documentation for Cashier can be found on the [Laravel website](https://laravel.
 
 ## Running Cashier's Tests
 
-You will need to set the Stripe **Testing** Secret env variable in a custom `phpunit.xml` file in order to run the Cashier tests.
+You will need to set the Stripe **Testing** secret environment variable in a custom `phpunit.xml` file in order to run the Cashier tests.
 
 Copy the file with `cp phpunit.xml.dist phpunit.xml` and add the following line below the `STRIPE_MODEL` env variable in the `phpunit.xml` file:
 

--- a/readme.md
+++ b/readme.md
@@ -17,11 +17,11 @@ Documentation for Cashier can be found on the [Laravel website](https://laravel.
 
 ## Running Cashier's Tests
 
-You will need to set the Stripe **Testing** secret environment variable in a custom `phpunit.xml` file in order to run the Cashier tests.
+You will need to set the Stripe **testing** secret environment variable in a custom `phpunit.xml` file in order to run the Cashier tests.
 
-Copy the file with `cp phpunit.xml.dist phpunit.xml` and add the following line below the `STRIPE_MODEL` env variable in the `phpunit.xml` file:
+Copy the default file using `cp phpunit.xml.dist phpunit.xml` and add the following line below the `STRIPE_MODEL` environment variable in your new `phpunit.xml` file:
 
-    <env name="STRIPE_SECRET" value="your Stripe secret key"/>
+    <env name="STRIPE_SECRET" value="Your Stripe Secret Key"/>
 
 Please note that due to the fact that actual API requests against Stripe are being made, these tests take a few minutes to run.
 

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Documentation for Cashier can be found on the [Laravel website](https://laravel.
 
 You will need to set the Stripe **Testing** Secret env variable in a custom `phpunit.xml` file in order to run the Cashier tests.
 
-Copy the file with `cp phpunit.xml.dist phpunit.xml` and add the following line below the `STRIPE_MODEL` env variable in the `phpunit.xml file:
+Copy the file with `cp phpunit.xml.dist phpunit.xml` and add the following line below the `STRIPE_MODEL` env variable in the `phpunit.xml` file:
 
     <env name="STRIPE_SECRET" value="your Stripe secret key"/>
 

--- a/readme.md
+++ b/readme.md
@@ -17,9 +17,11 @@ Documentation for Cashier can be found on the [Laravel website](https://laravel.
 
 ## Running Cashier's Tests
 
-You will need to set the Stripe **Testing** Secret env variable before your `vendor/bin/phpunit` call in order to run the Cashier tests:
+You will need to set the Stripe **Testing** Secret env variable in a custom `phpunit.xml` file in order to run the Cashier tests.
 
-    STRIPE_SECRET=<your Stripe secret> vendor/bin/phpunit
+Copy the file with `cp phpunit.xml.dist phpunit.xml` and add the following line below the `STRIPE_MODEL` env variable in the `phpunit.xml file:
+
+    <env name="STRIPE_SECRET" value="your Stripe secret key"/>
 
 Please note that due to the fact that actual API requests against Stripe are being made, these tests take a few minutes to run.
 


### PR DESCRIPTION
I realized that using and env variable in a CLI call isn't the best idea even though it's just a testing token. It's probably better that we use the `phpunit.xml` file like it was intended too.
