### PR TITLE
[9.0] Handle incomplete subscriptions upon creation

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,15 @@
 # Upgrade Guide
 
+## Upgrading To 9.3 From 9.2
+
+### Custom Subscription Creation Exception
+
+[In their 2019-03-14 API update](https://stripe.com/docs/upgrades#2019-03-14), Stripe changed the way they handle new subscriptions when card payment fails. Instead of letting the creation of the subscription fail, the subscription is failed with an "incomplete" status. Because of this a Cashier customer will always get a successful subscription. Previously a card exception was thrown.
+
+To accommodate for this new behavior from now on Cashier will cancel that subscription immediately and throw a custom `SubscriptionCreationFailed` exception when a subscription is created with an "incomplete" or "incomplete_expired" status. We've decided to do this because in general you want to let a customer only start using your product when payment was received.
+
+If you were relying on catching the `\Stripe\Error\Card` exception before you should now rely on catching the `Laravel\Cashier\Exceptions\SubscriptionCreationFailed` exception instead. 
+
 ## Upgrading To 9.0 From 8.0
 
 ### PHP & Laravel Version Requirements

--- a/src/Exceptions/SubscriptionCreationFailed.php
+++ b/src/Exceptions/SubscriptionCreationFailed.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Cashier\Exceptions;
+
+use Exception;
+use Stripe\Subscription;
+
+class SubscriptionCreationFailed extends Exception
+{
+    public static function incomplete(Subscription $subscription)
+    {
+        return new static("The attempt to create a subscription for plan \"{$subscription->plan->nickname}\" for customer \"{$subscription->customer}\" failed because the subscription was incomplete. For more information on incomplete subscriptions, see https://stripe.com/docs/billing/lifecycle#incomplete");
+    }
+}


### PR DESCRIPTION
Stripe changed the way failed payments for subscriptions are handled in their 2019-03-14 API update: https://stripe.com/docs/upgrades#2019-03-14

This means subscriptions still get created if the payment fails but they get an incomplete status which gives the customer 23 hours to pay. Since Cashier expects a subscription to be properly paid for we should handle this scenario gracefully.

In the previous API version a card exception was thrown when a payment failed so the only thing that changes with this change is that it's a different exception that's thrown. What also happens is that the subscription gets cancelled immediately if we detect an incomplete subscription so the invoice is voided and the customer isn't billed anymore. No subscription gets added to the billable entity so the developer implementing the feature only needs to handle the exception.

Since this is a bugfix it should be tagged as a patch release but since this also introduces a breaking change a minor release might be more appropriate. An entry to the upgrade guide might be worth considering. Doing a major update for this is overkill since we're actually fixing a bug here.

I'm also planning on working on https://github.com/laravel/cashier/issues/621 which should resolve these issues in general so we can incrementally do upgrades instead of fixing these problems ad-hoc whenever Stripe performs an update to their API.

**Todo:**

- [x] Handle plan swapping
- [x] Add entry to upgrade guide

**Update:** turns out that plan swapping doesn't needs to accommodate for this as it already throws a card declines error. However, I did notice that the subscription was updated regardless of the plan swapping or not. Maybe we need to look into this.

Fixes https://github.com/laravel/cashier/issues/628