### PR TITLE
[9.0] Able to update a Stripe customer

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -568,6 +568,21 @@ trait Billable
     }
 
     /**
+     * Update a Stripe customer for the given Stripe model.
+     *
+     * @param  array  $options
+     * @return \Stripe\Customer
+     */
+    public function updateStripeCustomer(array $options = [])
+    {
+        $customer = StripeCustomer::update(
+            $this->stripe_id, $options, $this->getStripeKey()
+        );
+
+        return $customer;
+    }
+
+    /**
      * Get the Stripe customer for the Stripe model.
      *
      * @return \Stripe\Customer

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -542,7 +542,7 @@ trait Billable
     }
 
     /**
-     * Create a Stripe customer for the given Stripe model.
+     * Create a Stripe customer for the given model.
      *
      * @param  array  $options
      * @return \Stripe\Customer
@@ -568,7 +568,7 @@ trait Billable
     }
 
     /**
-     * Update a Stripe customer for the given Stripe model.
+     * Update the underlying Stripe customer information for the model.
      *
      * @param  array  $options
      * @return \Stripe\Customer
@@ -583,7 +583,7 @@ trait Billable
     }
 
     /**
-     * Get the Stripe customer for the Stripe model.
+     * Get the Stripe customer for the model.
      *
      * @return \Stripe\Customer
      */

--- a/tests/Integration/CashierTest.php
+++ b/tests/Integration/CashierTest.php
@@ -555,6 +555,21 @@ class CashierTest extends TestCase
         $this->assertTrue($user->subscriptions()->ended()->exists());
     }
 
+    public function test_update_stripe_customer()
+    {
+        $user = User::create([
+            'email' => 'taylor@laravel.com',
+            'name' => 'Taylor Otwell',
+        ]);
+
+        $user->createAsStripeCustomer();
+
+        // Update the customers email
+        $customer = $user->updateStripeCustomer(['email' => 'test@laravel.com']);
+
+        $this->assertEquals('test@laravel.com', $customer->email);
+    }
+
     protected function getTestToken()
     {
         return Token::create([


### PR DESCRIPTION
You can update the customer data in Stripe. 

Usage: `$user->updateStripeCustomer(['email' => 'updated@customer.com']);`

Check available parameters on [Stripe](https://stripe.com/docs/api/customers/update)