### PR TITLE
[10.0] Split and cleanup integration tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,6 @@
         </testsuite>
     </testsuites>
     <php>
-        <env name="STRIPE_MODEL" value="Laravel\Cashier\Tests\Integration\User"/>
+        <env name="STRIPE_MODEL" value="Laravel\Cashier\Tests\Fixtures\User"/>
     </php>
 </phpunit>

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Fixtures;
+
+use Laravel\Cashier\Billable;
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    use Billable;
+}

--- a/tests/Integration/ChargesTest.php
+++ b/tests/Integration/ChargesTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Integration;
+
+use Stripe\Charge;
+
+class ChargesTest extends IntegrationTestCase
+{
+    public function test_customer_can_be_charged()
+    {
+        $user = $this->createCustomer('customer_can_be_charged');
+        $user->createAsStripeCustomer();
+        $user->updateCard($this->getTestToken());
+
+        $response = $user->charge(1000);
+
+        $this->assertInstanceOf(Charge::class, $response);
+        $this->assertEquals(1000, $response->amount);
+    }
+
+    public function test_customer_can_be_charged_and_invoiced_immediately()
+    {
+        $user = $this->createCustomer('customer_can_be_charged_and_invoiced_immediately');
+        $user->createAsStripeCustomer();
+        $user->updateCard($this->getTestToken());
+
+        $user->invoiceFor('Laravel Cashier', 1000);
+
+        $invoice = $user->invoices()[0];
+        $this->assertEquals('$10.00', $invoice->total());
+        $this->assertEquals('Laravel Cashier', $invoice->invoiceItems()[0]->asStripeInvoiceItem()->description);
+    }
+
+    public function test_customer_can_be_refunded()
+    {
+        $user = $this->createCustomer('customer_can_be_refunded');
+        $user->createAsStripeCustomer();
+        $user->updateCard($this->getTestToken());
+
+        $invoice = $user->invoiceFor('Laravel Cashier', 1000);
+        $refund = $user->refund($invoice->charge);
+
+        $this->assertEquals(1000, $refund->amount);
+    }
+}

--- a/tests/Integration/CustomerTest.php
+++ b/tests/Integration/CustomerTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Integration;
+
+class CustomerTest extends IntegrationTestCase
+{
+    public function test_customers_in_stripe_can_be_updated()
+    {
+        $user = $this->createCustomer('customers_in_stripe_can_be_updated');
+        $user->createAsStripeCustomer();
+
+        $customer = $user->updateStripeCustomer(['description' => 'Mohamed Said']);
+
+        $this->assertEquals('Mohamed Said', $customer->description);
+    }
+}

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Integration;
+
+use Stripe\Token;
+use Stripe\Stripe;
+use Stripe\ApiResource;
+use PHPUnit\Framework\TestCase;
+use Stripe\Error\InvalidRequest;
+use Illuminate\Database\Schema\Builder;
+use Laravel\Cashier\Tests\Fixtures\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+
+abstract class IntegrationTestCase extends TestCase
+{
+    /**
+     * @var string
+     */
+    protected static $stripePrefix = 'cashier-test-';
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        Stripe::setApiKey(getenv('STRIPE_SECRET'));
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Eloquent::unguard();
+
+        $db = new DB;
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->schema()->create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email');
+            $table->string('name');
+            $table->string('stripe_id')->nullable();
+            $table->string('card_brand')->nullable();
+            $table->string('card_last_four')->nullable();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('subscriptions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->string('name');
+            $table->string('stripe_id');
+            $table->string('stripe_plan');
+            $table->integer('quantity');
+            $table->timestamp('trial_ends_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function tearDown()
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('subscriptions');
+    }
+
+    protected static function deleteStripeResource(ApiResource $resource)
+    {
+        try {
+            $resource->delete();
+        } catch (InvalidRequest $e) {
+            //
+        }
+    }
+
+    protected function schema(): Builder
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+    protected function connection(): ConnectionInterface
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    protected function getTestToken($cardNumber = null)
+    {
+        return Token::create([
+            'card' => [
+                'number' => $cardNumber ?? '4242424242424242',
+                'exp_month' => 5,
+                'exp_year' => date('Y') + 1,
+                'cvc' => '123',
+            ],
+        ])->id;
+    }
+
+    protected function getInvalidCardToken()
+    {
+        return $this->getTestToken('4000 0000 0000 0341');
+    }
+
+    protected function createCustomer($description = 'taylor'): User
+    {
+        return User::create([
+            'email' => "{$description}@cashier-test.com",
+            'name' => 'Taylor Otwell',
+        ]);
+    }
+}

--- a/tests/Integration/WebhooksTest.php
+++ b/tests/Integration/WebhooksTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Integration;
+
+use Stripe\Plan;
+use Stripe\Product;
+use Illuminate\Support\Str;
+use Illuminate\Http\Request;
+use Laravel\Cashier\Http\Controllers\WebhookController;
+
+class WebhooksTest extends IntegrationTestCase
+{
+    /**
+     * @var string
+     */
+    protected static $productId;
+
+    /**
+     * @var string
+     */
+    protected static $planId;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        static::$productId = static::$stripePrefix.'product-1'.Str::random(10);
+        static::$planId = static::$stripePrefix.'monthly-10-'.Str::random(10);
+
+        Product::create([
+            'id' => static::$productId,
+            'name' => 'Laravel Cashier Test Product',
+            'type' => 'service',
+        ]);
+
+        Plan::create([
+            'id' => static::$planId,
+            'nickname' => 'Monthly $10',
+            'currency' => 'USD',
+            'interval' => 'month',
+            'billing_scheme' => 'per_unit',
+            'amount' => 1000,
+            'product' => static::$productId,
+        ]);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        parent::tearDownAfterClass();
+
+        static::deleteStripeResource(new Plan(static::$planId));
+        static::deleteStripeResource(new Product(static::$productId));
+    }
+
+    public function test_subscription_is_marked_as_cancelled_when_deleted_in_stripe()
+    {
+        $user = $this->createCustomer('subscription_is_marked_as_cancelled_when_deleted_in_stripe');
+        $user->newSubscription('main', static::$planId)
+            ->create($this->getTestToken());
+        $subscription = $user->subscription('main');
+
+        $response = (new CashierTestControllerStub)->handleWebhook(
+            Request::create('/', 'POST', [], [], [], [], json_encode([
+                'id' => 'foo',
+                'type' => 'customer.subscription.deleted',
+                'data' => [
+                    'object' => [
+                        'id' => $subscription->stripe_id,
+                        'customer' => $user->stripe_id,
+                    ],
+                ],
+            ]))
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertTrue($user->fresh()->subscription('main')->cancelled());
+    }
+}
+
+class CashierTestControllerStub extends WebhookController
+{
+    public function __construct()
+    {
+        // Prevent setting middleware...
+    }
+}

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Unit;
+
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+use Laravel\Cashier\Tests\Fixtures\User;
+
+class CustomerTest extends TestCase
+{
+    public function test_customer_can_be_put_on_a_generic_trial()
+    {
+        $user = new User;
+
+        $this->assertFalse($user->onGenericTrial());
+
+        $user->trial_ends_at = Carbon::tomorrow();
+
+        $this->assertTrue($user->onGenericTrial());
+
+        $user->trial_ends_at = Carbon::today()->subDays(5);
+
+        $this->assertFalse($user->onGenericTrial());
+    }
+}


### PR DESCRIPTION
This PR splits up the large Cashier integration testcase into several smaller ones. This makes it more clear where to add tests and keeps a better overview of the covered functionality. It's also easier for new comers to know where they need to add tests.

I've also added an improvement so the customer in Stripe doesn't has a generic email address anymore but rather a description which matches the test method so we know which case was covered for which customer in Stripe's test data.

Before:

![Screen Shot 2019-04-18 at 16 50 23](https://user-images.githubusercontent.com/594614/56370816-3926ae80-61fc-11e9-9d36-a2a654b568b3.png)

After:

![Screen Shot 2019-04-18 at 16 50 12](https://user-images.githubusercontent.com/594614/56370835-3e83f900-61fc-11e9-94db-23cd61c61f9d.png)

A downsize to this is that the email addresses are rather long and take up quite some UI space. Here's an example of the event log:

![Screen Shot 2019-04-18 at 17 07 18](https://user-images.githubusercontent.com/594614/56370926-66735c80-61fc-11e9-9e08-b51e8faee2e8.png)

If you want me to revert this or change this to something smaller let me know.

There's also a small downsize to this PR that because the test cases are now split up, the suite will sends api calls to create resources for both the `SubscriptionsTest` as well as the `WebhooksTest` but all in all it's not much of a loss in time. 