### PR TITLE
[10.0] Implement Stripe Checkout

### DIFF
--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -1,0 +1,25 @@
+<!-- Create a button that your customers click to complete their purchase. Customize the styling to suit your branding. -->
+<button
+    style="background-color:#6772E5;color:#FFF;padding:8px 12px;border:0;border-radius:4px;font-size:1em"
+    id="checkout-{{ $sessionId }}"
+    role="link"
+>
+    {{ $label }}
+</button>
+
+<div id="error-message"></div>
+
+<script>
+    var checkoutButton = document.getElementById('checkout-{{ $sessionId }}');
+
+    checkoutButton.addEventListener('click', function () {
+        // When the customer clicks on the button, redirect them to Checkout.
+        Stripe('{{ $stripeKey }}').redirectToCheckout({
+            sessionId: '{{ $sessionId }}'
+        }).then(function (result) {
+            // If `redirectToCheckout` fails due to a browser or network
+            // error, display the localized error message to your customer
+            // using `result.error.message`.
+        });
+    });
+</script>

--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -10,7 +10,7 @@
 <div id="error-message"></div>
 
 <script>
-    var checkoutButton = document.getElementById('checkout-{{ $sessionId }}');
+    const checkoutButton = document.getElementById('checkout-{{ $sessionId }}');
 
     checkoutButton.addEventListener('click', function () {
         // When the customer clicks on the button, redirect them to Checkout.

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier;
 use Exception;
 use InvalidArgumentException;
 use Stripe\Card as StripeCard;
+use Stripe\Checkout\Session;
 use Stripe\Token as StripeToken;
 use Illuminate\Support\Collection;
 use Stripe\Charge as StripeCharge;
@@ -44,6 +45,28 @@ trait Billable
         }
 
         return StripeCharge::create($options, Cashier::stripeOptions());
+    }
+
+    /**
+     * Begin a new Checkout Session.
+     *
+     * @param  int  $amount
+     * @param  string  $name
+     * @param  int  $quantity
+     * @param  array  $sessionOptions
+     * @param  array  $customerOptions
+     * @return \Laravel\Cashier\Checkout
+     */
+    public function checkout($amount, $name, $quantity = 1, array $sessionOptions = [], array $customerOptions = [])
+    {
+        return Checkout::create($this, array_merge([
+            'line_items' => [[
+                'name' => $name,
+                'amount' => $amount,
+                'currency' => $this->preferredCurrency(),
+                'quantity' => $quantity,
+            ]],
+        ], $sessionOptions), $customerOptions);
     }
 
     /**

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -3,9 +3,9 @@
 namespace Laravel\Cashier;
 
 use Exception;
+use Stripe\Checkout\Session;
 use InvalidArgumentException;
 use Stripe\Card as StripeCard;
-use Stripe\Checkout\Session;
 use Stripe\Token as StripeToken;
 use Illuminate\Support\Collection;
 use Stripe\Charge as StripeCharge;

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -31,6 +31,28 @@ class Checkout
     }
 
     /**
+     * Begin a new Checkout Session.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
+     * @param  array  $sessionOptions
+     * @param  array  $customerOptions
+     * @return \Laravel\Cashier\Checkout
+     */
+    public static function create($owner, array $sessionOptions = [], array $customerOptions = [])
+    {
+        $customer = $owner->createOrGetStripeCustomer($customerOptions);
+
+        $session = Session::create(array_merge([
+            'customer' => $customer->id,
+            'success_url' => route('cashier.checkout.success'),
+            'cancel_url' => route('cashier.checkout.cancelled'),
+            'payment_method_types' => ['card'],
+        ], $sessionOptions), Cashier::stripeOptions());
+
+        return new static($customer, $session);
+    }
+
+    /**
      * Get the View instance for the button.
      *
      * @param  string  $label

--- a/src/Checkout.php
+++ b/src/Checkout.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Laravel\Cashier;
+
+use Stripe\Checkout\Session;
+use Illuminate\Support\Facades\View;
+
+class Checkout
+{
+    /**
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $owner;
+
+    /**
+     * @var \Stripe\Checkout\Session
+     */
+    protected $session;
+
+    /**
+     * Create a new Checkout instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
+     * @param  \Stripe\Checkout\Session  $session
+     * @return void
+     */
+    public function __construct($owner, Session $session)
+    {
+        $this->owner = $owner;
+        $this->session = $session;
+    }
+
+    /**
+     * Get the View instance for the button.
+     *
+     * @param  string  $label
+     * @param  array  $options
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function button($label = 'Checkout', array $options = [])
+    {
+        return View::make('cashier::checkout', array_merge([
+            'label' => $label,
+            'stripeKey' => Cashier::stripeKey(),
+            'sessionId' => $this->session->id,
+        ], $options));
+    }
+
+    /**
+     * @return \Stripe\Checkout\Session
+     */
+    public function asStripeCheckoutSession()
+    {
+        return $this->session;
+    }
+}

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -242,9 +242,9 @@ class SubscriptionBuilder
         $minimumTrialPeriod = Carbon::now()->addHours(48);
 
         if ($this->trialExpires && $this->trialExpires->gt($minimumTrialPeriod)) {
-            $trialEnd = $this->trialExpires->getTimestamp();
+            $trialEnd = $this->trialExpires;
         } else {
-            $trialEnd = $minimumTrialPeriod->getTimestamp();
+            $trialEnd = $minimumTrialPeriod;
         }
 
         return Checkout::create($this->owner, array_merge([
@@ -256,7 +256,7 @@ class SubscriptionBuilder
                     ],
                 ],
                 'metadata' => $this->metadata,
-                'trial_end' => $trialEnd,
+                'trial_end' => $trialEnd->getTimestamp(),
             ],
         ], $sessionOptions), $customerOptions);
     }

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -255,6 +255,9 @@ class SubscriptionBuilder
             ],
         ], $sessionOptions), Cashier::stripeOptions());
 
+        // Todo: We should have the subscription id from here on. Already create subscription in database?
+        // See: https://stripe.com/docs/api/checkout/sessions/create
+
         return new Checkout($customer, $session);
     }
 

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -230,14 +230,15 @@ class SubscriptionBuilder
     /**
      * Begin a new Checkout Session.
      *
+     * @param  array  $sessionOptions
      * @param  array  $customerOptions
      * @return \Laravel\Cashier\Checkout
      */
-    public function checkout(array $customerOptions = [])
+    public function checkout(array $sessionOptions = [], array $customerOptions = [])
     {
         $customer = $this->owner->createOrGetStripeCustomer($customerOptions);
 
-        $session = Session::create([
+        $session = Session::create(array_merge([
             'customer' => $customer->id,
             'success_url' => route('cashier.checkout.success'),
             'cancel_url' => route('cashier.checkout.cancelled'),
@@ -252,7 +253,7 @@ class SubscriptionBuilder
                 'metadata' => $this->metadata,
                 'trial_end' => $this->getTrialEndForPayload(),
             ],
-        ], Cashier::stripeOptions());
+        ], $sessionOptions), Cashier::stripeOptions());
 
         return new Checkout($customer, $session);
     }

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -236,13 +236,7 @@ class SubscriptionBuilder
      */
     public function checkout(array $sessionOptions = [], array $customerOptions = [])
     {
-        $customer = $this->owner->createOrGetStripeCustomer($customerOptions);
-
-        $session = Session::create(array_merge([
-            'customer' => $customer->id,
-            'success_url' => route('cashier.checkout.success'),
-            'cancel_url' => route('cashier.checkout.cancelled'),
-            'payment_method_types' => ['card'],
+        return Checkout::create($this->owner, array_merge([
             'subscription_data' => [
                 'items' => [
                     [
@@ -253,12 +247,7 @@ class SubscriptionBuilder
                 'metadata' => $this->metadata,
                 'trial_end' => $this->getTrialEndForPayload(),
             ],
-        ], $sessionOptions), Cashier::stripeOptions());
-
-        // Todo: We should have the subscription id from here on. Already create subscription in database?
-        // See: https://stripe.com/docs/api/checkout/sessions/create
-
-        return new Checkout($customer, $session);
+        ], $sessionOptions), $customerOptions);
     }
 
     /**


### PR DESCRIPTION
This PR adds functionality for Stripe checkout. At the moment it'll initiate a new server side session so we can add the checkout to an existing user. Unfortunately I just discovered that this isn't implemented by Stripe yet: https://stripe.com/docs/payments/checkout/server#span-classstepoptionalspan-using-existing-customers

> You may specify an existing Customer object for Checkout to use when making one-time payments (this does not yet work with plans and subscriptions). 

We'll have to wait until Stripe implements this before continuing with subscriptions. We can already see at implementing checkout for single charges though.

## Todo

- [ ] Subscribing to plans
- [ ] Swapping plans
- [ ] Single charges
- [ ] Webhooks (Payment Fulfillments)
- [ ] Style button
- [ ] Tests
- [ ] Write documentation
- [ ] Prefill session id in success link: https://stripe.com/docs/payments/checkout/fulfillment#webhooks

## Concerns

Below I'll try to list all concerns I encounter during development.

### Existing customers can't yet be passed along when subscribing to a plan

This is vital for Cashier to work so until this gets implemented on Stripe's end this PR is basically blocked.

![Screen Shot 2019-04-26 at 20 48 58](https://user-images.githubusercontent.com/594614/56829675-b12c4e80-6864-11e9-828c-57df03ff5b6f.png)

https://stripe.com/docs/payments/checkout/migration#client-subscriptions

### Trial days seem to work differently for Checkout sessions ✅

Current api for subscriptions: https://stripe.com/docs/api/subscriptions/create#create_subscription-trial_end

![Screen Shot 2019-04-26 at 20 55 06](https://user-images.githubusercontent.com/594614/56830068-a6be8480-6865-11e9-9f76-b1a854854648.png)

Api when creating Checkout sessions: https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-subscription_data-trial_end

![Screen Shot 2019-04-26 at 20 54 41](https://user-images.githubusercontent.com/594614/56830078-afaf5600-6865-11e9-80c0-4c47eb6f288c.png)

This basically means that you're always required to give either a 48h period or 1 day period when subscribing through Checkout. This seems unwanted and weird. I'll check this over with Stripe.

Update 30/04: Stripe confirmed that the 48h limitation is in place for the following reason:

> Checkout Sessions are active for 24 hours after their creation and within that timeframe, your customer can complete the payment at any time. We require the trial start least 48 hours in the future so that there is still at least a 1 day trial if your customer pays at the end of the 24 hours.

I've implemented this here: https://github.com/laravel/cashier/commit/ff9946d4c88cbefdb483829da3a0f18612e57854

### Unclear how to upgrade or downgrade using Checkout

[The migration guide covers creating new subscriptions](https://stripe.com/docs/payments/checkout/migration#api-subscriptions) but no mention is made on how to [upgrade or downgrade plans](https://stripe.com/docs/billing/subscriptions/upgrading-downgrading). We'll need this before support for plan swapping can be given.

Update 29/04: [Stripe has confirmed that this isn't included yet.](https://twitter.com/stripe/status/1122737049268887557)

### Unclear how one-off invoices work

At the moment it's unclear how the `invoice` method on the billable entity would work with Checkout (or payment intents). [I've asked this question to Stripe on Twitter and awaiting their feedback.](https://twitter.com/driesvints/status/1122890720254279680)