### PR TITLE
[10.0] Add publishable key to Cashier

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -15,14 +15,14 @@ class Cashier
     const STRIPE_VERSION = '2019-03-14';
 
     /**
-     * The Stripe Publishable API key.
+     * The publishable Stripe API key.
      *
      * @var string
      */
     protected static $stripeKey;
 
     /**
-     * The Stripe Secret API key.
+     * The secret Stripe API key.
      *
      * @var string
      */

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -15,11 +15,18 @@ class Cashier
     const STRIPE_VERSION = '2019-03-14';
 
     /**
-     * The Stripe API key.
+     * The Stripe Publishable API key.
      *
      * @var string
      */
     protected static $stripeKey;
+
+    /**
+     * The Stripe Secret API key.
+     *
+     * @var string
+     */
+    protected static $stripeSecret;
 
     /**
      * The current currency.
@@ -43,7 +50,7 @@ class Cashier
     protected static $formatCurrencyUsing;
 
     /**
-     * Get the Stripe API key.
+     * Get the Stripe Publishable API key.
      *
      * @return string
      */
@@ -51,6 +58,35 @@ class Cashier
     {
         if (static::$stripeKey) {
             return static::$stripeKey;
+        }
+
+        if ($key = getenv('STRIPE_KEY')) {
+            return $key;
+        }
+
+        return config('services.stripe.key');
+    }
+
+    /**
+     * Set the Stripe Publishable API key.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public static function setStripeKey($key)
+    {
+        static::$stripeKey = $key;
+    }
+
+    /**
+     * Get the Stripe Secret API key.
+     *
+     * @return string
+     */
+    public static function stripeSecret()
+    {
+        if (static::$stripeSecret) {
+            return static::$stripeSecret;
         }
 
         if ($key = getenv('STRIPE_SECRET')) {
@@ -61,14 +97,14 @@ class Cashier
     }
 
     /**
-     * Set the Stripe API key.
+     * Set the Stripe Secret API key.
      *
      * @param  string  $key
      * @return void
      */
-    public static function setStripeKey($key)
+    public static function setStripeSecret($key)
     {
-        static::$stripeKey = $key;
+        static::$stripeSecret = $key;
     }
 
     /**
@@ -80,7 +116,7 @@ class Cashier
     public static function stripeOptions(array $options = [])
     {
         return array_merge([
-            'api_key' => static::stripeKey(),
+            'api_key' => static::stripeSecret(),
             'stripe_version' => static::STRIPE_VERSION,
         ], $options);
     }

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -50,7 +50,7 @@ class Cashier
     protected static $formatCurrencyUsing;
 
     /**
-     * Get the Stripe Publishable API key.
+     * Get the pulishable Stripe API key.
      *
      * @return string
      */
@@ -68,7 +68,7 @@ class Cashier
     }
 
     /**
-     * Set the Stripe Publishable API key.
+     * Set the publishable Stripe API key.
      *
      * @param  string  $key
      * @return void
@@ -79,7 +79,7 @@ class Cashier
     }
 
     /**
-     * Get the Stripe Secret API key.
+     * Get the secret Stripe API key.
      *
      * @return string
      */
@@ -97,7 +97,7 @@ class Cashier
     }
 
     /**
-     * Set the Stripe Secret API key.
+     * Set the secret Stripe API key.
      *
      * @param  string  $key
      * @return void


### PR DESCRIPTION
This PR modifies the keys in the Cashier object. It adds the publishable key which we'll use in upcoming prs to prefill the JS widgets we'll use for Checkout and Payment Intents. It also properly refactors the key names to their clear equivalents from Stripe.