### PR TITLE
[9.0] Fixing `defaultCard()` exception when not Stripe customer

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -379,6 +379,10 @@ trait Billable
      */
     public function defaultCard()
     {
+        if (! $this->hasStripeId()) {
+            return null;
+        }
+
         $customer = $this->asStripeCustomer();
 
         foreach ($customer->sources->data as $card) {

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -380,7 +380,7 @@ trait Billable
     public function defaultCard()
     {
         if (! $this->hasStripeId()) {
-            return null;
+            return;
         }
 
         $customer = $this->asStripeCustomer();

--- a/tests/Integration/CashierTest.php
+++ b/tests/Integration/CashierTest.php
@@ -267,18 +267,6 @@ class CashierTest extends TestCase
 
         // Assert that the defaultCard method returns null for billable models that are not stripe customers, and no exception is thrown
         $this->assertNull($user->defaultCard());
-
-        // Create the user as a stripe customer
-        $user->createAsStripeCustomer();
-
-        // Assert that the defaultCard method returns null if the user is a stripe customer but has no cards
-        $this->assertNull($user->defaultCard());
-
-        // Add a card to the stripe customer
-        $user->updateCard($this->getTestToken());
-
-        // Now that the user has a card on file, make sure it is returned as expected
-        $this->assertInstanceOf(Card::class, $user->defaultCard());
     }
 
     public function test_creating_subscription_fails_when_card_is_declined()


### PR DESCRIPTION
Hello Laravel Team!

Summary:
-------------
This pull request addresses an issue where the `defaultCard()` method on the billable trait would throw an exception if the model was not created as a stripe customer.

Expected:
------------
Calling the `defaultCard()` method will return null if the user has no card on file, even when the billable model is not set up as a Stripe customer.

Actual:
--------
An exception is thrown:
`Stripe\Error\InvalidRequest: Could not determine which URL to request: Stripe\Customer instance has invalid ID: `.

Fix:
----
Checking to make sure that the billable model has a stripe ID before attempting to retrieve the model as a stripe customer, so we are not sending the Stripe PHP library invalid data.
