### PR TITLE
[10.0] Ship migrations with package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
+        "orchestra/testbench": "^3.8",
         "phpunit/phpunit": "^7.5"
     },
     "autoload": {

--- a/database/migrations/2019_05_03_000001_create_customer_columns.php
+++ b/database/migrations/2019_05_03_000001_create_customer_columns.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateCustomerColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('stripe_id')->nullable()->collation('utf8mb4_bin');
+            $table->string('card_brand')->nullable();
+            $table->string('card_last_four', 4)->nullable();
+            $table->timestamp('trial_ends_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn([
+                'stripe_id',
+                'card_brand',
+                'card_last_four',
+                'trial_ends_at',
+            ]);
+        });
+    }
+}

--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateSubscriptionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('subscriptions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+            $table->string('name');
+            $table->string('stripe_id')->collation('utf8mb4_bin');
+            $table->string('stripe_plan');
+            $table->integer('quantity');
+            $table->timestamp('trial_ends_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('subscriptions');
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,7 @@
         </testsuite>
     </testsuites>
     <php>
+        <env name="DB_CONNECTION" value="testing"/>
         <env name="STRIPE_MODEL" value="Laravel\Cashier\Tests\Fixtures\User"/>
     </php>
 </phpunit>

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -50,6 +50,13 @@ class Cashier
     protected static $formatCurrencyUsing;
 
     /**
+     * Indicates if Cashier migrations will be run.
+     *
+     * @var bool
+     */
+    public static $runsMigrations = true;
+
+    /**
      * Get the publishable Stripe API key.
      *
      * @return string
@@ -230,5 +237,17 @@ class Cashier
         }
 
         return static::usesCurrencySymbol().$amount;
+    }
+
+    /**
+     * Configure Cashier to not register its migrations.
+     *
+     * @return static
+     */
+    public static function ignoreMigrations()
+    {
+        static::$runsMigrations = false;
+
+        return new static;
     }
 }

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -15,8 +15,28 @@ class CashierServiceProvider extends ServiceProvider
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'cashier');
 
-        $this->publishes([
-            __DIR__.'/../resources/views' => $this->app->basePath('resources/views/vendor/cashier'),
-        ]);
+        if ($this->app->runningInConsole()) {
+            $this->registerMigrations();
+
+            $this->publishes([
+                __DIR__.'/../database/migrations' => $this->app->databasePath('migrations'),
+            ], 'cashier-migrations');
+
+            $this->publishes([
+                __DIR__.'/../resources/views' => $this->app->resourcePath('views/vendor/cashier'),
+            ], 'cashier-views');
+        }
+    }
+
+    /**
+     * Register Cashier's migration files.
+     *
+     * @return void
+     */
+    protected function registerMigrations()
+    {
+        if (Cashier::$runsMigrations) {
+            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        }
     }
 }


### PR DESCRIPTION
This adds Cashier's migrations to the package itself so they're shipped with Cashier and can be published just like with Passport and Telescope. This also directly integrates the migrations into the test suite so they're tested. Orchestra testbench helps us to implement this.

I needed to update migrations for a future PR so I thought I'd implement this first.

Closes https://github.com/laravel/cashier/issues/639