### PR TITLE
[10.0] Use Stripe tokens in tests

### DIFF
--- a/tests/Integration/ChargesTest.php
+++ b/tests/Integration/ChargesTest.php
@@ -10,7 +10,7 @@ class ChargesTest extends IntegrationTestCase
     {
         $user = $this->createCustomer('customer_can_be_charged');
         $user->createAsStripeCustomer();
-        $user->updateCard($this->getTestToken());
+        $user->updateCard('tok_visa');
 
         $response = $user->charge(1000);
 
@@ -22,7 +22,7 @@ class ChargesTest extends IntegrationTestCase
     {
         $user = $this->createCustomer('customer_can_be_charged_and_invoiced_immediately');
         $user->createAsStripeCustomer();
-        $user->updateCard($this->getTestToken());
+        $user->updateCard('tok_visa');
 
         $user->invoiceFor('Laravel Cashier', 1000);
 
@@ -35,7 +35,7 @@ class ChargesTest extends IntegrationTestCase
     {
         $user = $this->createCustomer('customer_can_be_refunded');
         $user->createAsStripeCustomer();
-        $user->updateCard($this->getTestToken());
+        $user->updateCard('tok_visa');
 
         $invoice = $user->invoiceFor('Laravel Cashier', 1000);
         $refund = $user->refund($invoice->charge);

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Cashier\Tests\Integration;
 
-use Stripe\Token;
 use Stripe\Stripe;
 use Stripe\ApiResource;
 use Stripe\Error\InvalidRequest;
@@ -48,23 +47,6 @@ abstract class IntegrationTestCase extends TestCase
         } catch (InvalidRequest $e) {
             //
         }
-    }
-
-    protected function getTestToken($cardNumber = null)
-    {
-        return Token::create([
-            'card' => [
-                'number' => $cardNumber ?? '4242424242424242',
-                'exp_month' => 5,
-                'exp_year' => date('Y') + 1,
-                'cvc' => '123',
-            ],
-        ])->id;
-    }
-
-    protected function getInvalidCardToken()
-    {
-        return $this->getTestToken('4000 0000 0000 0341');
     }
 
     protected function createCustomer($description = 'taylor'): User

--- a/tests/Integration/SubscriptionsTest.php
+++ b/tests/Integration/SubscriptionsTest.php
@@ -108,7 +108,7 @@ class SubscriptionsTest extends IntegrationTestCase
         $user = $this->createCustomer('subscriptions_can_be_created');
 
         // Create Subscription
-        $user->newSubscription('main', static::$planId)->create($this->getTestToken());
+        $user->newSubscription('main', static::$planId)->create('tok_visa');
 
         $this->assertEquals(1, count($user->subscriptions));
         $this->assertNotNull($user->subscription('main')->stripe_id);
@@ -183,7 +183,7 @@ class SubscriptionsTest extends IntegrationTestCase
     public function test_swapping_subscription_with_coupon()
     {
         $user = $this->createCustomer('swapping_subscription_with_coupon');
-        $user->newSubscription('main', static::$planId)->create($this->getTestToken());
+        $user->newSubscription('main', static::$planId)->create('tok_visa');
         $subscription = $user->subscription('main');
 
         $subscription->swap(static::$otherPlanId, [
@@ -198,7 +198,7 @@ class SubscriptionsTest extends IntegrationTestCase
         $user = $this->createCustomer('creating_subscription_fails_when_card_is_declined');
 
         try {
-            $user->newSubscription('main', static::$planId)->create($this->getInvalidCardToken());
+            $user->newSubscription('main', static::$planId)->create('tok_chargeCustomerFail');
 
             $this->fail('Expected exception '.SubscriptionCreationFailed::class.' was not thrown.');
         } catch (SubscriptionCreationFailed $e) {
@@ -214,10 +214,10 @@ class SubscriptionsTest extends IntegrationTestCase
     {
         $user = $this->createCustomer('plan_swap_succeeds_even_if_payment_fails');
 
-        $subscription = $user->newSubscription('main', static::$planId)->create($this->getTestToken());
+        $subscription = $user->newSubscription('main', static::$planId)->create('tok_visa');
 
         // Set a faulty card as the customer's default card.
-        $user->updateCard($this->getInvalidCardToken());
+        $user->updateCard('tok_chargeCustomerFail');
 
         // Attempt to swap and pay with a faulty card.
         $subscription = $subscription->swap(static::$premiumPlanId);
@@ -233,7 +233,7 @@ class SubscriptionsTest extends IntegrationTestCase
         // Create Subscription
         $user->newSubscription('main', static::$planId)
             ->withCoupon(static::$couponId)
-            ->create($this->getTestToken());
+            ->create('tok_visa');
 
         $subscription = $user->subscription('main');
 
@@ -262,7 +262,7 @@ class SubscriptionsTest extends IntegrationTestCase
         // Create Subscription
         $user->newSubscription('main', static::$planId)
             ->anchorBillingCycleOn(new DateTime('first day of next month'))
-            ->create($this->getTestToken());
+            ->create('tok_visa');
 
         $subscription = $user->subscription('main');
 
@@ -296,7 +296,7 @@ class SubscriptionsTest extends IntegrationTestCase
         // Create Subscription
         $user->newSubscription('main', static::$planId)
             ->trialDays(7)
-            ->create($this->getTestToken());
+            ->create('tok_visa');
 
         $subscription = $user->subscription('main');
 
@@ -332,7 +332,7 @@ class SubscriptionsTest extends IntegrationTestCase
         // Create Subscription
         $user->newSubscription('main', static::$planId)
             ->trialUntil(Carbon::tomorrow()->hour(3)->minute(15))
-            ->create($this->getTestToken());
+            ->create('tok_visa');
 
         $subscription = $user->subscription('main');
 
@@ -365,9 +365,7 @@ class SubscriptionsTest extends IntegrationTestCase
     {
         $user = $this->createCustomer('applying_coupons_to_existing_customers');
 
-        // Create Subscription
-        $user->newSubscription('main', static::$planId)
-            ->create($this->getTestToken());
+        $user->newSubscription('main', static::$planId)->create('tok_visa');
 
         $user->applyCoupon(static::$couponId);
 

--- a/tests/Integration/WebhooksTest.php
+++ b/tests/Integration/WebhooksTest.php
@@ -55,9 +55,7 @@ class WebhooksTest extends IntegrationTestCase
     public function test_subscription_is_marked_as_cancelled_when_deleted_in_stripe()
     {
         $user = $this->createCustomer('subscription_is_marked_as_cancelled_when_deleted_in_stripe');
-        $user->newSubscription('main', static::$planId)
-            ->create($this->getTestToken());
-        $subscription = $user->subscription('main');
+        $subscription = $user->newSubscription('main', static::$planId)->create('tok_visa');
 
         $response = (new CashierTestControllerStub)->handleWebhook(
             Request::create('/', 'POST', [], [], [], [], json_encode([


### PR DESCRIPTION
It occurred to me that we could simply use the tokens Stripe provides to do the testing without making round trips to the api to create them ourselves.

See https://stripe.com/docs/testing#cards