### PR TITLE
[10.0] Billing SCA

### DIFF
--- a/src/Exceptions/SubscriptionCreationFailed.php
+++ b/src/Exceptions/SubscriptionCreationFailed.php
@@ -7,8 +7,8 @@ use Stripe\Subscription;
 
 class SubscriptionCreationFailed extends Exception
 {
-    public static function incomplete(Subscription $subscription)
+    public static function cardError(Subscription $subscription)
     {
-        return new static("The attempt to create a subscription for plan \"{$subscription->plan->nickname}\" for customer \"{$subscription->customer}\" failed because the subscription was incomplete. For more information on incomplete subscriptions, see https://stripe.com/docs/billing/lifecycle#incomplete");
+        return new static("The attempt to create a subscription for plan \"{$subscription->plan->nickname}\" for customer \"{$subscription->customer}\" failed because there was a card error.");
     }
 }

--- a/src/Exceptions/SubscriptionCreationIncomplete.php
+++ b/src/Exceptions/SubscriptionCreationIncomplete.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Cashier\Exceptions;
+
+use Exception;
+use Stripe\Subscription;
+
+class SubscriptionCreationIncomplete extends Exception
+{
+    public static function requiresAction(Subscription $subscription)
+    {
+        return new static("The attempt to create a subscription for plan \"{$subscription->plan->nickname}\" for customer \"{$subscription->customer}\" is incomplete and requires extra action.");
+    }
+}

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -206,12 +206,6 @@ class SubscriptionBuilder
         /** @var \Stripe\Subscription $subscription */
         $subscription = $customer->subscriptions->create($this->buildPayload());
 
-        if ($this->skipTrial) {
-            $trialEndsAt = null;
-        } else {
-            $trialEndsAt = $this->trialExpires;
-        }
-
         if (in_array($subscription->status, ['incomplete', 'incomplete_expired'])) {
             /** @var \Stripe\Invoice $latestInvoice */
             $latestInvoice = $subscription->latest_invoice;
@@ -225,6 +219,12 @@ class SubscriptionBuilder
             } elseif ($paymentIntent->status === 'requires_action') {
                 throw SubscriptionCreationIncomplete::requiresAction($subscription);
             }
+        }
+
+        if ($this->skipTrial) {
+            $trialEndsAt = null;
+        } else {
+            $trialEndsAt = $this->trialExpires;
         }
 
         return $this->owner->subscriptions()->create([

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier;
 use Carbon\Carbon;
 use DateTimeInterface;
 use Laravel\Cashier\Exceptions\SubscriptionCreationFailed;
+use Laravel\Cashier\Exceptions\SubscriptionCreationIncomplete;
 
 class SubscriptionBuilder
 {
@@ -222,7 +223,7 @@ class SubscriptionBuilder
 
                 throw SubscriptionCreationFailed::cardError($subscription);
             } elseif ($paymentIntent->status === 'requires_action') {
-                // Needs extra payment action: 3D Secure,...
+                throw SubscriptionCreationIncomplete::requiresAction($subscription);
             }
         }
 


### PR DESCRIPTION
This PR aimes at updating the subscription based billing with the payment intents API to verify payments using 3D secure, amongst else. 

There's still quite a bit to figure out but getting there slowly.

**Todo**

- [ ] Implement a generic way to verify payment intents 
- [ ] Update plan swapping
- [ ] Add comment blocks in places where they provide value

**Resources**

- https://stripe.com/docs/billing/migration/strong-customer-authentication
- https://stripe.com/docs/billing/subscriptions/payment#handling-action-required
- https://stripe.com/docs/payments/payment-intents

**Concerns**

1. **Use incomplete status as well for failed payments**

At the moment we immediately cancel a subscription when its initial payment fails. But maybe we should allow the customer a chance to use a different payment method first? At the moment his causes Stripe to be polluted with failed subscriptions and voided invoices. It would be better if the invoice just stayed open until paid.