### PR TITLE
Adding in an optional parameter to swap method so users can update metadata when changing plans

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -348,11 +348,13 @@ class Subscription extends Model
      * @param  string  $plan
      * @return $this
      */
-    public function swap($plan)
+    public function swap($plan, $metadata = [])
     {
         $subscription = $this->asStripeSubscription();
 
         $subscription->plan = $plan;
+
+        $subscription->metadata = $metadata;
 
         $subscription->prorate = $this->prorate;
 


### PR DESCRIPTION
Currently the SubscriptionBuilder allows you to add metadata to a subscription with the ->withMetadata([]) method. However, there is no way to modify the subscriptions metadata while swapping plans.

This is beneficial as the metadata is often related to the subscription plan itself, so if a user needed to include metadata when creating the subscription there is a good chance they will need to update that metadata when they swap plans.

This is fully backwards compatible as the $metadata parameter defaults to a blank array, and setting $subscription->metadata = [] has no effect in Stripe, so it will not overwrite or delete existing metadata attributes, it only allows you to update or add new metadata if a value is passed in.