### PR TITLE
[10.0] Register webhook route with the package

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,5 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::post('webhook', 'WebhookController@handleWebhook')->name('webhook');

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -2,25 +2,70 @@
 
 namespace Laravel\Cashier;
 
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Contracts\Routing\Registrar;
 
 class CashierServiceProvider extends ServiceProvider
 {
     /**
-     * Bootstrap the application events.
+     * Bootstrap any package services.
      *
      * @return void
      */
     public function boot()
     {
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'cashier');
-
         $this->registerRoutes();
+        $this->registerResources();
+        $this->registerMigrations();
+        $this->registerPublishing();
+    }
 
+    /**
+     * Register the package routes.
+     *
+     * @return void
+     */
+    protected function registerRoutes()
+    {
+        Route::group([
+            'prefix' => 'stripe',
+            'namespace' => 'Laravel\Cashier\Http\Controllers',
+            'as' => 'cashier.',
+        ], function () {
+            $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+        });
+    }
+
+    /**
+     * Register the package resources.
+     *
+     * @return void
+     */
+    protected function registerResources()
+    {
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'cashier');
+    }
+
+    /**
+     * Register the package migrations.
+     *
+     * @return void
+     */
+    protected function registerMigrations()
+    {
+        if (Cashier::$runsMigrations && $this->app->runningInConsole()) {
+            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        }
+    }
+
+    /**
+     * Register the package's publishable resources.
+     *
+     * @return void
+     */
+    protected function registerPublishing()
+    {
         if ($this->app->runningInConsole()) {
-            $this->registerMigrations();
-
             $this->publishes([
                 __DIR__.'/../database/migrations' => $this->app->databasePath('migrations'),
             ], 'cashier-migrations');
@@ -29,53 +74,5 @@ class CashierServiceProvider extends ServiceProvider
                 __DIR__.'/../resources/views' => $this->app->resourcePath('views/vendor/cashier'),
             ], 'cashier-views');
         }
-    }
-
-    /**
-     * Register Cashier's migration files.
-     *
-     * @return void
-     */
-    protected function registerMigrations()
-    {
-        if (Cashier::$runsMigrations) {
-            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
-        }
-    }
-
-    /**
-     * Register Cashier's routes.
-     *
-     * @return void
-     */
-    protected function registerRoutes()
-    {
-        $this->router()->group($this->routeConfiguration(), function (Registrar $router) {
-            $router->post('webhook', 'WebhookController@handleWebhook')->name('webhook');
-        });
-    }
-
-    /**
-     * The Illuminate route registrar.
-     *
-     * @return \Illuminate\Contracts\Routing\Registrar
-     */
-    protected function router()
-    {
-        return $this->app->make(Registrar::class);
-    }
-
-    /**
-     * Get the Cashier route group configuration array.
-     *
-     * @return array
-     */
-    protected function routeConfiguration()
-    {
-        return [
-            'namespace' => 'Laravel\Cashier\Http\Controllers',
-            'prefix' => 'stripe',
-            'as' => 'cashier.',
-        ];
     }
 }

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Laravel\Cashier;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Routing\Registrar;
 
 class CashierServiceProvider extends ServiceProvider
 {
@@ -14,6 +15,8 @@ class CashierServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'cashier');
+
+        $this->registerRoutes();
 
         if ($this->app->runningInConsole()) {
             $this->registerMigrations();
@@ -38,5 +41,41 @@ class CashierServiceProvider extends ServiceProvider
         if (Cashier::$runsMigrations) {
             $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         }
+    }
+
+    /**
+     * Register Cashier's routes.
+     *
+     * @return void
+     */
+    protected function registerRoutes()
+    {
+        $this->router()->group($this->routeConfiguration(), function (Registrar $router) {
+            $router->post('webhook', 'WebhookController@handleWebhook')->name('webhook');
+        });
+    }
+
+    /**
+     * The Illuminate route registrar.
+     *
+     * @return \Illuminate\Contracts\Routing\Registrar
+     */
+    protected function router()
+    {
+        return $this->app->make(Registrar::class);
+    }
+
+    /**
+     * Get the Cashier route group configuration array.
+     *
+     * @return array
+     */
+    protected function routeConfiguration()
+    {
+        return [
+            'namespace' => 'Laravel\Cashier\Http\Controllers',
+            'prefix' => 'stripe',
+            'as' => 'cashier.',
+        ];
     }
 }


### PR DESCRIPTION
This commit auto-registers the webhook endpoint with the package so the user doesn't has to do this themselves. They can still override it in their own routes file. Benefit of this is also that our integration test is now an actual endpoint test.

In an upcoming PR another route for payment intents will be added.