### PR TITLE
[9.0] Remove strict type check for trialUntil()

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -39,7 +39,7 @@ class SubscriptionBuilder
     /**
      * The date and time the trial will expire.
      *
-     * @var \Carbon\Carbon
+     * @var \Carbon\Carbon|\Carbon\CarbonInterface
      */
     protected $trialExpires;
 
@@ -115,7 +115,7 @@ class SubscriptionBuilder
     /**
      * Specify the ending date of the trial.
      *
-     * @param  \Carbon\Carbon  $trialUntil
+     * @param  \Carbon\Carbon|\Carbon\CarbonInterface  $trialUntil
      * @return $this
      */
     public function trialUntil($trialUntil)

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -118,7 +118,7 @@ class SubscriptionBuilder
      * @param  \Carbon\Carbon  $trialUntil
      * @return $this
      */
-    public function trialUntil(Carbon $trialUntil)
+    public function trialUntil($trialUntil)
     {
         $this->trialExpires = $trialUntil;
 


### PR DESCRIPTION
This removes the type check for a `Carbon` object in `trialUntil()` because those using Carbon 2 may also pass a `CarbonImmutable` object.