### PR TITLE
[10.0] Fix customer while charging

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -36,7 +36,7 @@ trait Billable
 
         $options['amount'] = $amount;
 
-        if (! array_key_exists('source', $options) && $this->stripe_id) {
+        if ($this->stripe_id) {
             $options['customer'] = $this->stripe_id;
         }
 

--- a/tests/Integration/ChargesTest.php
+++ b/tests/Integration/ChargesTest.php
@@ -3,6 +3,7 @@
 namespace Laravel\Cashier\Tests\Integration;
 
 use Stripe\Charge;
+use Stripe\Error\InvalidRequest;
 
 class ChargesTest extends IntegrationTestCase
 {
@@ -16,6 +17,28 @@ class ChargesTest extends IntegrationTestCase
 
         $this->assertInstanceOf(Charge::class, $response);
         $this->assertEquals(1000, $response->amount);
+        $this->assertEquals($user->stripe_id, $response->customer);
+    }
+
+    public function test_customer_cannot_be_charged_with_custom_source()
+    {
+        $user = $this->createCustomer('customer_can_be_charged_with_custom_source');
+        $user->createAsStripeCustomer();
+
+        $this->expectException(InvalidRequest::class);
+
+        $user->charge(1000, ['source' => 'tok_visa']);
+    }
+
+    public function test_non_stripe_customer_can_be_charged()
+    {
+        $user = $this->createCustomer('non_stripe_customer_can_be_charged');
+
+        $response = $user->charge(1000, ['source' => 'tok_visa']);
+
+        $this->assertInstanceOf(Charge::class, $response);
+        $this->assertEquals(1000, $response->amount);
+        $this->assertNull($response->customer);
     }
 
     public function test_customer_can_be_charged_and_invoiced_immediately()


### PR DESCRIPTION
When a single charge is performed and the billable entity is a stripe customer it's not set when a custom source is passed. This PR fixes this behavior to allow single charges to stripe customers with a different payment source. If the payment source isn't attached to the customer the Stripe API call will fail. This is now also covered with tests.