### PR TITLE
[9.0] Fix hasStartingBalance and subtotal on Invoice

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -78,7 +78,7 @@ class Invoice
     public function subtotal()
     {
         return $this->formatAmount(
-            max(0, $this->invoice->subtotal - $this->rawStartingBalance())
+            max(0, $this->invoice->subtotal - ($this->rawStartingBalance() * -1))
         );
     }
 
@@ -89,7 +89,7 @@ class Invoice
      */
     public function hasStartingBalance()
     {
-        return $this->rawStartingBalance() > 0;
+        return $this->rawStartingBalance() < 0;
     }
 
     /**


### PR DESCRIPTION
hasStartingBalance currently returns false if a customer has credit on its account. This is because Stripe returns the credit as a negative value. This subsequently also affects the subtotal. We'll use the same solution as the total and reverse the negative.