### PR TITLE
[10.0] Fix subscription reactivation

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -77,10 +77,14 @@ class WebhookController extends Controller
                 }
 
                 // Cancellation date...
-                if (isset($data['cancel_at_period_end']) && $data['cancel_at_period_end']) {
-                    $subscription->ends_at = $subscription->onTrial()
-                                ? $subscription->trial_ends_at
-                                : Carbon::createFromTimestamp($data['current_period_end']);
+                if (isset($data['cancel_at_period_end'])) {
+                    if ($data['cancel_at_period_end']) {
+                        $subscription->ends_at = $subscription->onTrial()
+                            ? $subscription->trial_ends_at
+                            : Carbon::createFromTimestamp($data['current_period_end']);
+                    } else {
+                        $subscription->ends_at = null;
+                    }
                 }
 
                 $subscription->save();


### PR DESCRIPTION
When resuming a cancelled subscription from Stripe, Cashier currently doesn't properly re-activates the subscription in the app. This change properly sets the ends_at value to null so the subscription is resumed.

See https://github.com/laravel/cashier/pull/629

Fixes https://github.com/laravel/cashier/issues/669
