### PR TITLE
[10.0] Implement config file

### DIFF
--- a/config/cashier.php
+++ b/config/cashier.php
@@ -1,0 +1,73 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stripe Keys
+    |--------------------------------------------------------------------------
+    |
+    | The Stripe publishable key and secret key give you access to Stripe's
+    | API. The Publishable key allows you to interact with public requests
+    | like the Stripe.js widgets and the secret key allows you to perform
+    | signed requests to retrieve and write your private dashboard data.
+    |
+    */
+
+    'key' => env('STRIPE_KEY'),
+
+    'secret' => env('STRIPE_SECRET'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stripe Webhooks
+    |--------------------------------------------------------------------------
+    |
+    | These settings control the webhook secret and tolerance level for
+    | incoming Stripe webhook requests.
+    |
+    */
+
+    'webhook' => [
+        'secret' => env('STRIPE_WEBHOOK_SECRET'),
+        'tolerance' => env('STRIPE_WEBHOOK_TOLERANCE', 300),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cashier Model
+    |--------------------------------------------------------------------------
+    |
+    | This is the model in your all that will implement the Billable trait.
+    | It'll be the primary model to perform Cashier related methods on and
+    | where subscriptions get attached to.
+    |
+    */
+
+    'model' => env('CASHIER_MODEL', App\User::class),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Currency
+    |--------------------------------------------------------------------------
+    |
+    | This is the default currency that'll be used to make charges with.
+    |
+    */
+
+    'currency' => env('CASHIER_CURRENCY', 'usd'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Currency Locale
+    |--------------------------------------------------------------------------
+    |
+    | This is the default locale in which your money values are formatted in.
+    | To use other locales besides the default "en" locale, make sure you have
+    | the ext-intl installed on your environment.
+    |
+    */
+
+    'currency_locale' => env('CASHIER_CURRENCY_LOCALE', 'en'),
+
+];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,6 @@
     </testsuites>
     <php>
         <env name="DB_CONNECTION" value="testing"/>
-        <env name="STRIPE_MODEL" value="Laravel\Cashier\Tests\Fixtures\User"/>
+        <env name="CASHIER_MODEL" value="Laravel\Cashier\Tests\Fixtures\User"/>
     </php>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Documentation for Cashier can be found on the [Laravel website](https://laravel.
 
 You will need to set the Stripe **testing** secret environment variable in a custom `phpunit.xml` file in order to run the Cashier tests.
 
-Copy the default file using `cp phpunit.xml.dist phpunit.xml` and add the following line below the `STRIPE_MODEL` environment variable in your new `phpunit.xml` file:
+Copy the default file using `cp phpunit.xml.dist phpunit.xml` and add the following line below the `CASHIER_MODEL` environment variable in your new `phpunit.xml` file:
 
     <env name="STRIPE_SECRET" value="Your Stripe Secret Key"/>
 

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -628,7 +628,7 @@ trait Billable
      */
     public function preferredCurrency()
     {
-        return Cashier::usesCurrency();
+        return config('cashier.currency');
     }
 
     /**

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -18,37 +18,6 @@ class Cashier
     const STRIPE_VERSION = '2019-03-14';
 
     /**
-     * The publishable Stripe API key.
-     *
-     * @var string
-     */
-    protected static $stripeKey;
-
-    /**
-     * The secret Stripe API key.
-     *
-     * @var string
-     */
-    protected static $stripeSecret;
-
-    /**
-     * The current currency.
-     *
-     * @var string
-     */
-    protected static $currency = 'usd';
-
-    /**
-     * The locale used to format money values.
-     *
-     * To use more locales besides the default "en" locale, make
-     * sure you have the ext-intl installed on your environment.
-     *
-     * @var string
-     */
-    protected static $currencyLocale = 'en';
-
-    /**
      * The custom currency formatter.
      *
      * @var callable
@@ -63,64 +32,6 @@ class Cashier
     public static $runsMigrations = true;
 
     /**
-     * Get the publishable Stripe API key.
-     *
-     * @return string
-     */
-    public static function stripeKey()
-    {
-        if (static::$stripeKey) {
-            return static::$stripeKey;
-        }
-
-        if ($key = getenv('STRIPE_KEY')) {
-            return $key;
-        }
-
-        return config('services.stripe.key');
-    }
-
-    /**
-     * Set the publishable Stripe API key.
-     *
-     * @param  string  $key
-     * @return void
-     */
-    public static function setStripeKey($key)
-    {
-        static::$stripeKey = $key;
-    }
-
-    /**
-     * Get the secret Stripe API key.
-     *
-     * @return string
-     */
-    public static function stripeSecret()
-    {
-        if (static::$stripeSecret) {
-            return static::$stripeSecret;
-        }
-
-        if ($key = getenv('STRIPE_SECRET')) {
-            return $key;
-        }
-
-        return config('services.stripe.secret');
-    }
-
-    /**
-     * Set the secret Stripe API key.
-     *
-     * @param  string  $key
-     * @return void
-     */
-    public static function setStripeSecret($key)
-    {
-        static::$stripeSecret = $key;
-    }
-
-    /**
      * Get the default Stripe API options.
      *
      * @param  array  $options
@@ -129,51 +40,9 @@ class Cashier
     public static function stripeOptions(array $options = [])
     {
         return array_merge([
-            'api_key' => static::stripeSecret(),
+            'api_key' => config('cashier.secret'),
             'stripe_version' => static::STRIPE_VERSION,
         ], $options);
-    }
-
-    /**
-     * Get the class name of the billable model.
-     *
-     * @return string
-     */
-    public static function stripeModel()
-    {
-        return getenv('STRIPE_MODEL') ?: config('services.stripe.model', 'App\\User');
-    }
-
-    /**
-     * Set the currency to be used when billing Stripe models.
-     *
-     * @param  string  $currency
-     * @return void
-     */
-    public static function useCurrency($currency)
-    {
-        static::$currency = $currency;
-    }
-
-    /**
-     * Get the currency currently in use.
-     *
-     * @return string
-     */
-    public static function usesCurrency()
-    {
-        return static::$currency;
-    }
-
-    /**
-     * Set the currency locale to format money.
-     *
-     * @param  string  $currencyLocale
-     * @return void
-     */
-    public static function useCurrencyLocale($currencyLocale)
-    {
-        static::$currencyLocale = $currencyLocale;
     }
 
     /**
@@ -200,9 +69,9 @@ class Cashier
             return call_user_func(static::$formatCurrencyUsing, $amount, $currency);
         }
 
-        $money = new Money($amount, new Currency(strtoupper($currency ?? static::usesCurrency())));
+        $money = new Money($amount, new Currency(strtoupper($currency ?? config('cashier.currency'))));
 
-        $numberFormatter = new NumberFormatter(static::$currencyLocale, NumberFormatter::CURRENCY);
+        $numberFormatter = new NumberFormatter(config('cashier.currency_locale'), NumberFormatter::CURRENCY);
         $moneyFormatter = new IntlMoneyFormatter($numberFormatter, new ISOCurrencies());
 
         return $moneyFormatter->format($money);

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -21,6 +21,28 @@ class CashierServiceProvider extends ServiceProvider
     }
 
     /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->configure();
+    }
+
+    /**
+     * Setup the configuration for Cashier.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/cashier.php', 'cashier'
+        );
+    }
+
+    /**
      * Register the package routes.
      *
      * @return void
@@ -66,6 +88,10 @@ class CashierServiceProvider extends ServiceProvider
     protected function registerPublishing()
     {
         if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/cashier.php' => $this->app->configPath('cashier.php'),
+            ], 'cashier-config');
+
             $this->publishes([
                 __DIR__.'/../database/migrations' => $this->app->databasePath('migrations'),
             ], 'cashier-migrations');

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -4,7 +4,6 @@ namespace Laravel\Cashier\Http\Controllers;
 
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
-use Laravel\Cashier\Cashier;
 use Illuminate\Support\Carbon;
 use Laravel\Cashier\Subscription;
 use Illuminate\Routing\Controller;
@@ -20,7 +19,7 @@ class WebhookController extends Controller
      */
     public function __construct()
     {
-        if (config('services.stripe.webhook.secret')) {
+        if (config('cashier.webhook.secret')) {
             $this->middleware(VerifyWebhookSignature::class);
         }
     }
@@ -171,7 +170,7 @@ class WebhookController extends Controller
      */
     protected function getUserByStripeId($stripeId)
     {
-        $model = Cashier::stripeModel();
+        $model = config('cashier.model');
 
         return (new $model)->where('stripe_id', $stripeId)->first();
     }

--- a/src/Http/Middleware/VerifyWebhookSignature.php
+++ b/src/Http/Middleware/VerifyWebhookSignature.php
@@ -50,8 +50,8 @@ class VerifyWebhookSignature
             WebhookSignature::verifyHeader(
                 $request->getContent(),
                 $request->header('Stripe-Signature'),
-                $this->config->get('services.stripe.webhook.secret'),
-                $this->config->get('services.stripe.webhook.tolerance')
+                $this->config->get('cashier.webhook.secret'),
+                $this->config->get('cashier.webhook.tolerance')
             );
         } catch (SignatureVerification $exception) {
             $this->app->abort(403);

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -58,9 +58,9 @@ class Subscription extends Model
      */
     public function owner()
     {
-        $class = Cashier::stripeModel();
+        $model = config('cashier.model');
 
-        return $this->belongsTo($class, (new $class)->getForeignKey());
+        return $this->belongsTo($model, (new $model)->getForeignKey());
     }
 
     /**

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -5,9 +5,8 @@ namespace Laravel\Cashier\Tests\Integration;
 use Stripe\Stripe;
 use Stripe\ApiResource;
 use Stripe\Error\InvalidRequest;
-use Orchestra\Testbench\TestCase;
+use Laravel\Cashier\Tests\TestCase;
 use Laravel\Cashier\Tests\Fixtures\User;
-use Laravel\Cashier\CashierServiceProvider;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
 abstract class IntegrationTestCase extends TestCase
@@ -33,11 +32,6 @@ abstract class IntegrationTestCase extends TestCase
         $this->loadLaravelMigrations();
 
         $this->artisan('migrate')->run();
-    }
-
-    protected function getPackageProviders($app)
-    {
-        return [CashierServiceProvider::class];
     }
 
     protected static function deleteStripeResource(ApiResource $resource)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laravel\Cashier\Tests;
+
+use Laravel\Cashier\CashierServiceProvider;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+
+abstract class TestCase extends OrchestraTestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [CashierServiceProvider::class];
+    }
+}

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -7,13 +7,13 @@ use Carbon\Carbon;
 use Stripe\Discount;
 use Carbon\CarbonTimeZone;
 use Laravel\Cashier\Invoice;
-use PHPUnit\Framework\TestCase;
+use Laravel\Cashier\Tests\TestCase;
 use Stripe\Invoice as StripeInvoice;
 use Laravel\Cashier\Tests\Fixtures\User;
 
 class InvoiceTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
 

--- a/tests/Unit/VerifyWebhookSignatureTest.php
+++ b/tests/Unit/VerifyWebhookSignatureTest.php
@@ -79,8 +79,8 @@ class VerifierMock
     {
         $this->app = m::mock(Application::class);
         $this->config = m::mock(Config::class);
-        $this->config->shouldReceive('get')->with('services.stripe.webhook.secret')->andReturn($webhookSecret);
-        $this->config->shouldReceive('get')->with('services.stripe.webhook.tolerance')->andReturn(300);
+        $this->config->shouldReceive('get')->with('cashier.webhook.secret')->andReturn($webhookSecret);
+        $this->config->shouldReceive('get')->with('cashier.webhook.tolerance')->andReturn(300);
         $this->request = new Request([], [], [], [], [], [], 'Signed Body');
     }
 


### PR DESCRIPTION
Cashier is at the moment one of the only Laravel packages which doesn't uses a config file. I think it would be better if it was more in line of the other packages by making use of one. This is what people are used to as well. These changes add a config file and cleans up the way configuration is handled within cashier.

An additional benefit is that the config for the stripe keys and web hooks is now included in Cashier itself and not outside of it anymore in the default `services.php` config file which ships with the Laravel skeleton. This keeps everything in exactly the place where you expect it to be and makes more sense.

Some configuration was kept in the `Cashier` class like the custom money formatting (closure which can't be in a config file) and the disabling of migrations (aligned with Passport and something you'd explicitly want to do in a service provider).

Another small change is the rename of `STRIPE_MODEL` to `CASHIER_MODEL` since that env variable is Cashier specfic and not Stripe specific.

This also allows us to easily add new config options in later pull requests (like the email reminder option in the payment intents PR).

Closes https://github.com/laravel/cashier/issues/531
