### PR TITLE
[10.0] Drop Carbon 1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/support": "~5.8.0|~5.9.0",
         "illuminate/view": "~5.8.0|~5.9.0",
         "moneyphp/money": "^3.2",
-        "nesbot/carbon": "^1.26.3|^2.0",
+        "nesbot/carbon": "^2.0",
         "stripe/stripe-php": "^6.0",
         "symfony/http-kernel": "^4.2",
         "symfony/intl": "^4.3"


### PR DESCRIPTION
Because it's unsupported. We already dropped it for the next laravel/framework release as well.