### PR TITLE
[10.0] Implement SetupIntent create method

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -9,6 +9,7 @@ use Stripe\Invoice as StripeInvoice;
 use Stripe\Customer as StripeCustomer;
 use Stripe\BankAccount as StripeBankAccount;
 use Stripe\InvoiceItem as StripeInvoiceItem;
+use Stripe\SetupIntent as StripeSetupIntent;
 use Stripe\Error\Card as StripeCardException;
 use Stripe\PaymentIntent as StripePaymentIntent;
 use Stripe\PaymentMethod as StripePaymentMethod;
@@ -338,6 +339,23 @@ trait Billable
     public function invoicesIncludingPending(array $parameters = [])
     {
         return $this->invoices(true, $parameters);
+    }
+
+    /**
+     * Create a new SetupIntent instance.
+     *
+     * @param  array  $options
+     * @return \Stripe\SetupIntent
+     */
+    public function createSetupIntent(array $options = [])
+    {
+        if ($this->stripe_id) {
+            $options['customer'] = $this->stripe_id;
+        }
+
+        return StripeSetupIntent::create(
+            $options, Cashier::stripeOptions()
+        );
     }
 
     /**

--- a/tests/Integration/PaymentMethodsTest.php
+++ b/tests/Integration/PaymentMethodsTest.php
@@ -5,10 +5,22 @@ namespace Laravel\Cashier\Tests\Integration;
 use Laravel\Cashier\Cashier;
 use Stripe\Card as StripeCard;
 use Laravel\Cashier\PaymentMethod;
+use Stripe\SetupIntent as StripeSetupIntent;
 use Stripe\PaymentMethod as StripePaymentMethod;
 
 class PaymentMethodsTest extends IntegrationTestCase
 {
+    public function test_we_can_start_a_new_setup_intents_session()
+    {
+        $user = $this->createCustomer('we_can_start_a_new_setup_intents_session');
+        $customer = $user->createAsStripeCustomer();
+
+        $setupIntent = $user->createSetupIntent();
+
+        $this->assertInstanceOf(StripeSetupIntent::class, $setupIntent);
+        $this->assertEquals($customer->id, $setupIntent->customer);
+    }
+
     public function test_we_can_set_a_default_payment_method()
     {
         $user = $this->createCustomer('we_can_set_a_default_payment_method');


### PR DESCRIPTION
This will easily help users start a new setup intent session to set up payment methods.

More info here: https://stripe.com/docs/payments/cards/saving-cards#saving-card-without-payment
