### PR TITLE
[10.0] Additional payment methods functionality

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -424,7 +424,7 @@ trait Billable
      * @param  string  $paymentMethod
      * @return void
      */
-    public function updatePaymentMethod($paymentMethod)
+    public function updateDefaultPaymentMethod($paymentMethod)
     {
         $this->assertCustomerExists();
 
@@ -458,11 +458,11 @@ trait Billable
     }
 
     /**
-     * Synchronises the customer's payment method from Stripe back into the database.
+     * Synchronises the customer's default payment method from Stripe back into the database.
      *
      * @return $this
      */
-    public function updatePaymentMethodFromStripe()
+    public function updateDefaultPaymentMethodFromStripe()
     {
         $defaultPaymentMethod = $this->defaultPaymentMethod();
 
@@ -532,7 +532,7 @@ trait Billable
             $paymentMethod->delete();
         });
 
-        $this->updatePaymentMethodFromStripe();
+        $this->updateDefaultPaymentMethodFromStripe();
     }
 
     /**

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -135,7 +135,7 @@ class WebhookController extends Controller
     protected function handleCustomerUpdated(array $payload)
     {
         if ($user = $this->getUserByStripeId($payload['data']['object']['id'])) {
-            $user->updatePaymentMethodFromStripe();
+            $user->updateDefaultPaymentMethodFromStripe();
         }
 
         return new Response('Webhook Handled', 200);

--- a/src/PaymentMethod.php
+++ b/src/PaymentMethod.php
@@ -40,7 +40,7 @@ class PaymentMethod
      */
     public function delete()
     {
-        return $this->paymentMethod->detach(null, Cashier::stripeOptions());
+        return $this->owner->removePaymentMethod($this->paymentMethod);
     }
 
     /**

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -193,7 +193,7 @@ class SubscriptionBuilder
     /**
      * Create a new Stripe subscription.
      *
-     * @param  string|null  $paymentMethod
+     * @param  \Stripe\PaymentMethod|string|null  $paymentMethod
      * @param  array  $options
      * @return \Laravel\Cashier\Subscription
      */
@@ -234,7 +234,7 @@ class SubscriptionBuilder
     /**
      * Get the Stripe customer instance for the current user and payment method.
      *
-     * @param  string|null  $paymentMethod
+     * @param  \Stripe\PaymentMethod|string|null  $paymentMethod
      * @param  array  $options
      * @return \Stripe\Customer
      */

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -243,7 +243,7 @@ class SubscriptionBuilder
         $customer = $this->owner->createOrGetStripeCustomer($options);
 
         if ($paymentMethod) {
-            $this->owner->updatePaymentMethod($paymentMethod);
+            $this->owner->updateDefaultPaymentMethod($paymentMethod);
         }
 
         return $customer;

--- a/tests/Integration/ChargesTest.php
+++ b/tests/Integration/ChargesTest.php
@@ -34,7 +34,7 @@ class ChargesTest extends IntegrationTestCase
     {
         $user = $this->createCustomer('customer_can_be_charged_and_invoiced_immediately');
         $user->createAsStripeCustomer();
-        $user->updatePaymentMethod('pm_card_visa');
+        $user->updateDefaultPaymentMethod('pm_card_visa');
 
         $user->invoiceFor('Laravel Cashier', 1000);
 
@@ -47,7 +47,7 @@ class ChargesTest extends IntegrationTestCase
     {
         $user = $this->createCustomer('customer_can_be_refunded');
         $user->createAsStripeCustomer();
-        $user->updatePaymentMethod('pm_card_visa');
+        $user->updateDefaultPaymentMethod('pm_card_visa');
 
         $invoice = $user->invoiceFor('Laravel Cashier', 1000);
         $refund = $user->refund($invoice->payment_intent);

--- a/tests/Integration/InvoicesTest.php
+++ b/tests/Integration/InvoicesTest.php
@@ -20,7 +20,7 @@ class InvoicesTest extends IntegrationTestCase
     {
         $user = $this->createCustomer('invoicing_fails_with_nothing_to_invoice');
         $user->createAsStripeCustomer();
-        $user->updatePaymentMethod('pm_card_visa');
+        $user->updateDefaultPaymentMethod('pm_card_visa');
 
         $response = $user->invoice();
 
@@ -31,7 +31,7 @@ class InvoicesTest extends IntegrationTestCase
     {
         $user = $this->createCustomer('customer_can_be_invoiced');
         $user->createAsStripeCustomer();
-        $user->updatePaymentMethod('pm_card_visa');
+        $user->updateDefaultPaymentMethod('pm_card_visa');
 
         $response = $user->invoiceFor('Laracon', 49900);
 

--- a/tests/Integration/PaymentMethodsTest.php
+++ b/tests/Integration/PaymentMethodsTest.php
@@ -26,7 +26,7 @@ class PaymentMethodsTest extends IntegrationTestCase
         $user = $this->createCustomer('we_can_set_a_default_payment_method');
         $user->createAsStripeCustomer();
 
-        $user->updatePaymentMethod('pm_card_visa');
+        $user->updateDefaultPaymentMethod('pm_card_visa');
         $paymentMethod = $user->defaultPaymentMethod();
 
         $this->assertInstanceOf(PaymentMethod::class, $paymentMethod);
@@ -68,7 +68,7 @@ class PaymentMethodsTest extends IntegrationTestCase
         $this->assertEquals('visa', $paymentMethods->last()->card->brand);
     }
 
-    public function test_we_can_sync_the_payment_method_from_stripe()
+    public function test_we_can_sync_the_default_payment_method_from_stripe()
     {
         $user = $this->createCustomer('we_can_sync_the_payment_method_from_stripe');
         $customer = $user->createAsStripeCustomer();
@@ -85,7 +85,7 @@ class PaymentMethodsTest extends IntegrationTestCase
         $this->assertNull($user->card_brand);
         $this->assertNull($user->card_last_four);
 
-        $user = $user->updatePaymentMethodFromStripe();
+        $user = $user->updateDefaultPaymentMethodFromStripe();
 
         $this->assertEquals('visa', $user->card_brand);
         $this->assertEquals('4242', $user->card_last_four);

--- a/tests/Integration/SubscriptionsTest.php
+++ b/tests/Integration/SubscriptionsTest.php
@@ -242,7 +242,7 @@ class SubscriptionsTest extends IntegrationTestCase
         $subscription = $user->newSubscription('main', static::$planId)->create('pm_card_visa');
 
         // Set a faulty card as the customer's default payment method.
-        $user->updatePaymentMethod('pm_card_chargeCustomerFail');
+        $user->updateDefaultPaymentMethod('pm_card_chargeCustomerFail');
 
         try {
             // Attempt to swap and pay with a faulty card.
@@ -268,7 +268,7 @@ class SubscriptionsTest extends IntegrationTestCase
         $subscription = $user->newSubscription('main', static::$planId)->create('pm_card_visa');
 
         // Set a card that requires a next action as the customer's default payment method.
-        $user->updatePaymentMethod('pm_card_threeDSecure2Required');
+        $user->updateDefaultPaymentMethod('pm_card_threeDSecure2Required');
 
         try {
             // Attempt to swap and pay with a faulty card.
@@ -294,7 +294,7 @@ class SubscriptionsTest extends IntegrationTestCase
         $subscription = $user->newSubscription('main', static::$premiumPlanId)->create('pm_card_visa');
 
         // Set a card that requires a next action as the customer's default payment method.
-        $user->updatePaymentMethod('pm_card_chargeCustomerFail');
+        $user->updateDefaultPaymentMethod('pm_card_chargeCustomerFail');
 
         // Attempt to swap and pay with a faulty card.
         $subscription = $subscription->swap(static::$planId);
@@ -313,7 +313,7 @@ class SubscriptionsTest extends IntegrationTestCase
         $subscription = $user->newSubscription('main', static::$premiumPlanId)->create('pm_card_visa');
 
         // Set a card that requires a next action as the customer's default payment method.
-        $user->updatePaymentMethod('pm_card_chargeCustomerFail');
+        $user->updateDefaultPaymentMethod('pm_card_chargeCustomerFail');
 
         // Attempt to swap and pay with a faulty card.
         $subscription = $subscription->swap(static::$planId);


### PR DESCRIPTION
This PR adds two additional methods to add and remove payment methods to the billable user. This way, apps can easily save more than one payment method for their store/checkout process. I've also renamed the default payment methods to make them more clear.