### PR TITLE
[10.0] Fix createSetupIntent

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -349,10 +349,6 @@ trait Billable
      */
     public function createSetupIntent(array $options = [])
     {
-        if ($this->stripe_id) {
-            $options['customer'] = $this->stripe_id;
-        }
-
         return StripeSetupIntent::create(
             $options, Cashier::stripeOptions()
         );

--- a/tests/Integration/PaymentMethodsTest.php
+++ b/tests/Integration/PaymentMethodsTest.php
@@ -13,12 +13,10 @@ class PaymentMethodsTest extends IntegrationTestCase
     public function test_we_can_start_a_new_setup_intent_session()
     {
         $user = $this->createCustomer('we_can_start_a_new_setup_intent_session');
-        $customer = $user->createAsStripeCustomer();
 
         $setupIntent = $user->createSetupIntent();
 
         $this->assertInstanceOf(StripeSetupIntent::class, $setupIntent);
-        $this->assertEquals($customer->id, $setupIntent->customer);
     }
 
     public function test_we_can_add_payment_methods()


### PR DESCRIPTION
Remove the customer parameter from the createSetupIntent method because new payment methods couldn't be associated with it.