### PR TITLE
[10.0] Improve stripe statuses

### DIFF
--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -17,8 +17,8 @@ class CreateSubscriptionsTable extends Migration
             $table->bigIncrements('id');
             $table->unsignedBigInteger('user_id');
             $table->string('name');
-            $table->string('status');
             $table->string('stripe_id')->collation('utf8mb4_bin');
+            $table->string('stripe_status');
             $table->string('stripe_plan');
             $table->integer('quantity');
             $table->timestamp('trial_ends_at')->nullable();

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -198,6 +198,20 @@ trait Billable
     }
 
     /**
+     * Determine if the customer's subscription has an incomplete payment.
+     *
+     * @return bool
+     */
+    public function hasIncompletePayment()
+    {
+        if ($subscription = $this->subscription()) {
+            return $subscription->hasIncompletePayment();
+        }
+
+        return false;
+    }
+
+    /**
      * Invoice the billable entity outside of regular billing cycle.
      *
      * @param  array  $options
@@ -218,7 +232,10 @@ trait Billable
             return false;
         } catch (StripeCardException $exception) {
             $payment = new Payment(
-                StripePaymentIntent::retrieve($invoice->refresh()->payment_intent, Cashier::stripeOptions())
+                StripePaymentIntent::retrieve(
+                    ['id' => $invoice->refresh()->payment_intent, 'expand' => ['invoice.subscription']],
+                    Cashier::stripeOptions()
+                )
             );
 
             $payment->validate();

--- a/src/Exceptions/SubscriptionUpdateFailure.php
+++ b/src/Exceptions/SubscriptionUpdateFailure.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravel\Cashier\Exceptions;
+
+use Exception;
+use Laravel\Cashier\Subscription;
+
+class SubscriptionUpdateFailure extends Exception
+{
+    /**
+     * Create a new SubscriptionUpdateFailure instance.
+     *
+     * @param  \Laravel\Cashier\Subscription  $subscription
+     * @param  string  $plan
+     * @return self
+     */
+    public static function incompleteSubscription(Subscription $subscription)
+    {
+        return new static("The subscription \"{$subscription->stripe_id}\" cannot be updated because its payment is incomplete.");
+    }
+}

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -93,11 +93,7 @@ class WebhookController extends Controller
 
                 // Status...
                 if (isset($data['status'])) {
-                    if (in_array($data['status'], ['incomplete', 'incomplete_expired'])) {
-                        $subscription->status = 'incomplete';
-                    } else {
-                        $subscription->status = 'active';
-                    }
+                    $subscription->stripe_status = $data['status'];
                 }
 
                 $subscription->save();

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -61,6 +61,12 @@ class WebhookController extends Controller
             $user->subscriptions->filter(function (Subscription $subscription) use ($data) {
                 return $subscription->stripe_id === $data['id'];
             })->each(function (Subscription $subscription) use ($data) {
+                if (isset($data['status']) && $data['status'] === 'incomplete_expired') {
+                    $subscription->delete();
+
+                    return;
+                }
+
                 // Quantity...
                 if (isset($data['quantity'])) {
                     $subscription->quantity = $data['quantity'];

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -81,7 +81,7 @@ class Subscription extends Model
      */
     public function incomplete()
     {
-        return $this->status === 'incomplete';
+        return $this->stripe_status === 'incomplete';
     }
 
     /**
@@ -92,17 +92,28 @@ class Subscription extends Model
      */
     public function scopeIncomplete($query)
     {
-        $query->where('status', 'incomplete');
+        $query->where('stripe_status', 'incomplete');
     }
 
     /**
-     * Mark the subscription as incomplete.
+     * Determine if the subscription is past due.
      *
+     * @return bool
+     */
+    public function pastDue()
+    {
+        return $this->stripe_status === 'past_due';
+    }
+
+    /**
+     * Filter query by past due.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return void
      */
-    public function markAsIncomplete()
+    public function scopePastDue($query)
     {
-        $this->fill(['status' => 'incomplete'])->save();
+        $query->where('stripe_status', 'past_due');
     }
 
     /**
@@ -124,20 +135,10 @@ class Subscription extends Model
     public function scopeActive($query)
     {
         $query->whereNull('ends_at')
-                ->where('status', '!=', 'incomplete')
+                ->where('stripe_status', '!=', 'incomplete')
                 ->orWhere(function ($query) {
                     $query->onGracePeriod();
                 });
-    }
-
-    /**
-     * Mark the subscription as active.
-     *
-     * @return void
-     */
-    public function markAsActive()
-    {
-        $this->fill(['status' => 'active'])->save();
     }
 
     /**
@@ -429,7 +430,7 @@ class Subscription extends Model
             $subscription->quantity = $this->quantity;
         }
 
-        $subscription->save();
+        $subscription = $subscription->save();
 
         $this->fill([
             'stripe_plan' => $plan,
@@ -439,7 +440,9 @@ class Subscription extends Model
         try {
             $this->user->invoice(['subscription' => $subscription->id]);
         } catch (IncompletePayment $exception) {
-            $this->markAsIncomplete();
+            $this->fill([
+                'stripe_status' => $exception->payment->invoice->subscription->status,
+            ])->save();
 
             throw $exception;
         }
@@ -458,7 +461,9 @@ class Subscription extends Model
 
         $subscription->cancel_at_period_end = true;
 
-        $subscription->save();
+        $subscription = $subscription->save();
+
+        $this->stripe_status = $subscription->status;
 
         // If the user was on trial, we will set the grace period to end when the trial
         // would have ended. Otherwise, we'll retrieve the end of the billing period
@@ -499,7 +504,10 @@ class Subscription extends Model
      */
     public function markAsCancelled()
     {
-        $this->fill(['ends_at' => Carbon::now()])->save();
+        $this->fill([
+            'stripe_status' => 'canceled',
+            'ends_at' => Carbon::now(),
+        ])->save();
     }
 
     /**
@@ -529,12 +537,15 @@ class Subscription extends Model
             $subscription->trial_end = 'now';
         }
 
-        $subscription->save();
+        $subscription = $subscription->save();
 
         // Finally, we will remove the ending timestamp from the user's record in the
         // local database to indicate that the subscription is active again and is
         // no longer "cancelled". Then we will save this record in the database.
-        $this->fill(['ends_at' => null])->save();
+        $this->fill([
+            'stripe_status' => $subscription->status,
+            'ends_at' => null,
+        ])->save();
 
         return $this;
     }
@@ -551,6 +562,16 @@ class Subscription extends Model
         $subscription->tax_percent = $this->user->taxPercentage();
 
         $subscription->save();
+    }
+
+    /**
+     * Determine if the subscription has an incomplete payment.
+     *
+     * @return bool
+     */
+    public function hasIncompletePayment()
+    {
+        return $this->pastDue() || $this->incomplete();
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -3,12 +3,12 @@
 namespace Laravel\Cashier;
 
 use Carbon\Carbon;
-use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use LogicException;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use Stripe\Subscription as StripeSubscription;
 use Laravel\Cashier\Exceptions\IncompletePayment;
+use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 
 class Subscription extends Model
 {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -3,6 +3,7 @@
 namespace Laravel\Cashier;
 
 use Carbon\Carbon;
+use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use LogicException;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
@@ -326,9 +327,15 @@ class Subscription extends Model
      * @param  int  $quantity
      * @param  \Stripe\Customer|null  $customer
      * @return $this
+     *
+     * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
      */
     public function updateQuantity($quantity, $customer = null)
     {
+        if ($this->incomplete()) {
+            throw SubscriptionUpdateFailure::incompleteSubscription($this);
+        }
+
         $subscription = $this->asStripeSubscription();
 
         $subscription->quantity = $quantity;
@@ -395,9 +402,14 @@ class Subscription extends Model
      * @return $this
      *
      * @throws \Laravel\Cashier\Exceptions\IncompletePayment
+     * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
      */
     public function swap($plan, $options = [])
     {
+        if ($this->incomplete()) {
+            throw SubscriptionUpdateFailure::incompleteSubscription($this);
+        }
+
         $subscription = $this->asStripeSubscription();
 
         $subscription->plan = $plan;

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -212,17 +212,15 @@ class SubscriptionBuilder
 
         $subscription = $this->owner->subscriptions()->create([
             'name' => $this->name,
-            'status' => 'active',
             'stripe_id' => $stripeSubscription->id,
+            'stripe_status' => $stripeSubscription->status,
             'stripe_plan' => $this->plan,
             'quantity' => $this->quantity,
             'trial_ends_at' => $trialEndsAt,
             'ends_at' => null,
         ]);
 
-        if ($stripeSubscription->status === 'incomplete') {
-            $subscription->markAsIncomplete();
-
+        if ($subscription->incomplete()) {
             (new Payment(
                 $stripeSubscription->latest_invoice->payment_intent
             ))->validate();

--- a/tests/Integration/SubscriptionsTest.php
+++ b/tests/Integration/SubscriptionsTest.php
@@ -257,8 +257,8 @@ class SubscriptionsTest extends IntegrationTestCase
             // Assert that the plan was swapped anyway.
             $this->assertEquals(static::$premiumPlanId, $subscription->refresh()->stripe_plan);
 
-            // Assert subscription is incomplete.
-            $this->assertTrue($subscription->incomplete());
+            // Assert subscription is past due.
+            $this->assertTrue($subscription->pastDue());
         }
     }
 
@@ -283,8 +283,8 @@ class SubscriptionsTest extends IntegrationTestCase
             // Assert that the plan was swapped anyway.
             $this->assertEquals(static::$premiumPlanId, $subscription->refresh()->stripe_plan);
 
-            // Assert subscription is incomplete.
-            $this->assertTrue($subscription->incomplete());
+            // Assert subscription is past due.
+            $this->assertTrue($subscription->pastDue());
         }
     }
 
@@ -481,8 +481,8 @@ class SubscriptionsTest extends IntegrationTestCase
         // Start with an incomplete subscription.
         $subscription = $user->subscriptions()->create([
             'name' => 'yearly',
-            'status' => 'incomplete',
             'stripe_id' => 'xxxx',
+            'stripe_status' => 'incomplete',
             'stripe_plan' => 'stripe-yearly',
             'quantity' => 1,
             'trial_ends_at' => null,
@@ -502,7 +502,7 @@ class SubscriptionsTest extends IntegrationTestCase
         $this->assertFalse($user->subscriptions()->ended()->exists());
 
         // Activate.
-        $subscription->update(['status' => 'active']);
+        $subscription->update(['stripe_status' => 'active']);
 
         $this->assertFalse($user->subscriptions()->incomplete()->exists());
         $this->assertTrue($user->subscriptions()->active()->exists());

--- a/tests/Integration/WebhooksTest.php
+++ b/tests/Integration/WebhooksTest.php
@@ -117,7 +117,6 @@ class WebhooksTest extends IntegrationTestCase
         ])->assertOk();
 
         $this->assertEmpty($user->refresh()->subscriptions, 'Subscription was not deleted.');
-
     }
 
     public function test_payment_action_required_email_is_sent()

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -9,31 +9,69 @@ class SubscriptionTest extends TestCase
 {
     public function test_we_can_check_if_a_subscription_is_incomplete()
     {
-        $subscription = new Subscription(['status' => 'incomplete']);
+        $subscription = new Subscription(['stripe_status' => 'incomplete']);
 
         $this->assertTrue($subscription->incomplete());
+        $this->assertFalse($subscription->pastDue());
         $this->assertFalse($subscription->active());
+    }
+    public function test_we_can_check_if_a_subscription_is_past_due()
+    {
+        $subscription = new Subscription(['stripe_status' => 'past_due']);
+
+        $this->assertFalse($subscription->incomplete());
+        $this->assertTrue($subscription->pastDue());
+        $this->assertTrue($subscription->active());
     }
 
     public function test_we_can_check_if_a_subscription_is_active()
     {
-        $subscription = new Subscription(['status' => 'active']);
+        $subscription = new Subscription(['stripe_status' => 'active']);
 
         $this->assertFalse($subscription->incomplete());
+        $this->assertFalse($subscription->pastDue());
         $this->assertTrue($subscription->active());
     }
 
     public function test_an_incomplete_subscription_is_not_valid()
     {
-        $subscription = new Subscription(['status' => 'incomplete']);
+        $subscription = new Subscription(['stripe_status' => 'incomplete']);
 
         $this->assertFalse($subscription->valid());
     }
 
-    public function test_an_active_subscription_is_valid()
+    public function test_a_past_due_subscription_is_valid()
     {
-        $subscription = new Subscription(['status' => 'active']);
+        $subscription = new Subscription(['stripe_status' => 'past_due']);
 
         $this->assertTrue($subscription->valid());
+    }
+
+    public function test_an_active_subscription_is_valid()
+    {
+        $subscription = new Subscription(['stripe_status' => 'active']);
+
+        $this->assertTrue($subscription->valid());
+    }
+
+    public function test_payment_is_incomplete_when_status_is_incomplete()
+    {
+        $subscription = new Subscription(['stripe_status' => 'incomplete']);
+
+        $this->assertTrue($subscription->hasIncompletePayment());
+    }
+
+    public function test_payment_is_incomplete_when_status_is_past_due()
+    {
+        $subscription = new Subscription(['stripe_status' => 'past_due']);
+
+        $this->assertTrue($subscription->hasIncompletePayment());
+    }
+
+    public function test_payment_is_not_incomplete_when_status_is_active()
+    {
+        $subscription = new Subscription(['stripe_status' => 'active']);
+
+        $this->assertFalse($subscription->hasIncompletePayment());
     }
 }

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Tests\Unit;
 
+use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use PHPUnit\Framework\TestCase;
 use Laravel\Cashier\Subscription;
 
@@ -73,5 +74,23 @@ class SubscriptionTest extends TestCase
         $subscription = new Subscription(['stripe_status' => 'active']);
 
         $this->assertFalse($subscription->hasIncompletePayment());
+    }
+
+    public function test_incomplete_subscriptions_cannot_be_swapped()
+    {
+        $subscription = new Subscription(['stripe_status' => 'incomplete']);
+
+        $this->expectException(SubscriptionUpdateFailure::class);
+
+        $subscription->swap('premium_plan');
+    }
+
+    public function test_incomplete_subscriptions_cannot_update_their_quantity()
+    {
+        $subscription = new Subscription(['stripe_status' => 'incomplete']);
+
+        $this->expectException(SubscriptionUpdateFailure::class);
+
+        $subscription->updateQuantity(5);
     }
 }

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -2,9 +2,9 @@
 
 namespace Laravel\Cashier\Tests\Unit;
 
-use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use PHPUnit\Framework\TestCase;
 use Laravel\Cashier\Subscription;
+use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 
 class SubscriptionTest extends TestCase
 {
@@ -16,6 +16,7 @@ class SubscriptionTest extends TestCase
         $this->assertFalse($subscription->pastDue());
         $this->assertFalse($subscription->active());
     }
+
     public function test_we_can_check_if_a_subscription_is_past_due()
     {
         $subscription = new Subscription(['stripe_status' => 'past_due']);


### PR DESCRIPTION
These changes sync the Stripe status within Cashier. This allows us to make better decisions when payments fail. There's also a new `hasIncompletePayment` method on both the billable trait and subscription model so it's easy to determine if a payment needs to be completed.

Subscriptions with an `incomplete_expired` status will be deleted from the app because they serve no purpose anymore.