### PR TITLE
[10.0] Fix subscription invoicing

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -212,7 +212,7 @@ trait Billable
     }
 
     /**
-     * Invoice the billable entity outside of regular billing cycle.
+     * Invoice the billable entity outside of the regular billing cycle.
      *
      * @param  array  $options
      * @return \Stripe\Invoice|bool

--- a/tests/Integration/SubscriptionsTest.php
+++ b/tests/Integration/SubscriptionsTest.php
@@ -168,8 +168,8 @@ class SubscriptionsTest extends IntegrationTestCase
 
         $this->assertEquals(1, $subscription->quantity);
 
-        // Swap Plan
-        $subscription->swap(static::$otherPlanId);
+        // Swap Plan and invoice immediately.
+        $subscription->swapAndInvoice(static::$otherPlanId);
 
         $this->assertEquals(static::$otherPlanId, $subscription->stripe_plan);
 
@@ -247,7 +247,7 @@ class SubscriptionsTest extends IntegrationTestCase
 
         try {
             // Attempt to swap and pay with a faulty card.
-            $subscription = $subscription->swap(static::$premiumPlanId);
+            $subscription = $subscription->swapAndInvoice(static::$premiumPlanId);
 
             $this->fail('Expected exception '.PaymentFailure::class.' was not thrown.');
         } catch (PaymentFailure $e) {
@@ -273,7 +273,7 @@ class SubscriptionsTest extends IntegrationTestCase
 
         try {
             // Attempt to swap and pay with a faulty card.
-            $subscription = $subscription->swap(static::$premiumPlanId);
+            $subscription = $subscription->swapAndInvoice(static::$premiumPlanId);
 
             $this->fail('Expected exception '.PaymentActionRequired::class.' was not thrown.');
         } catch (PaymentActionRequired $e) {


### PR DESCRIPTION
These changes make sure that the `incrementAndInvoice` method also throws the SCA exceptions. It also adds a `swapAndInvoice` method which has the previous `swap` method behavior. The `swap` method now doesn't invoices the user immediately.
