### PR TITLE
[10.0] Return invoice object when applicable

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -581,11 +581,11 @@ class Subscription extends Model
      * Invoice the subscription outside of the regular billing cycle.
      *
      * @param  array  $options
-     * @return \Stripe\Invoice|bool
+     * @return \Laravel\Cashier\Invoice|bool
      *
      * @throws \Laravel\Cashier\Exceptions\IncompletePayment
      */
-    protected function invoice(array $options = [])
+    public function invoice(array $options = [])
     {
         try {
             return $this->user->invoice(array_merge($options, ['subscription' => $this->stripe_id]));

--- a/tests/Integration/InvoicesTest.php
+++ b/tests/Integration/InvoicesTest.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Cashier\Tests\Integration;
 
-use Stripe\Invoice;
+use Laravel\Cashier\Invoice;
 use Laravel\Cashier\Exceptions\InvalidStripeCustomer;
 
 class InvoicesTest extends IntegrationTestCase


### PR DESCRIPTION
This PR makes sure that an Cashier invoice object is returned when applicable instead of a Stripe invoice object.