### PR TITLE
[10.0] Re-enable proration

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -312,6 +312,18 @@ class Subscription extends Model
     }
 
     /**
+     * Indicate that the plan change should be prorated.
+     *
+     * @return $this
+     */
+    public function prorate()
+    {
+        $this->prorate = true;
+
+        return $this;
+    }
+
+    /**
      * Change the billing cycle anchor on a plan change.
      *
      * @param  \DateTimeInterface|int|string  $date

--- a/tests/Integration/CashierTest.php
+++ b/tests/Integration/CashierTest.php
@@ -70,7 +70,7 @@ class CashierTest extends TestCase
         static::$planId = static::$stripePrefix.'monthly-10-'.Str::random(10);
         static::$otherPlanId = static::$stripePrefix.'monthly-10-'.Str::random(10);
         static::$premiumPlanId = static::$stripePrefix.'monthly-20-premium-'.Str::random(10);
-        static::$couponId = static::$stripePrefix.'coupon-' . Str::random(10);
+        static::$couponId = static::$stripePrefix.'coupon-'.Str::random(10);
 
         Product::create([
             'id' => static::$productId,

--- a/tests/Integration/CashierTest.php
+++ b/tests/Integration/CashierTest.php
@@ -66,11 +66,11 @@ class CashierTest extends TestCase
 
     protected static function setUpStripeTestData()
     {
-        static::$productId = static::$stripePrefix . 'product-1' . Str::random(10);
-        static::$planId = static::$stripePrefix . 'monthly-10-' . Str::random(10);
-        static::$otherPlanId = static::$stripePrefix . 'monthly-10-' . Str::random(10);
-        static::$premiumPlanId = static::$stripePrefix . 'monthly-20-premium-' . Str::random(10);
-        static::$couponId = static::$stripePrefix . 'coupon-' . Str::random(10);
+        static::$productId = static::$stripePrefix.'product-1'.Str::random(10);
+        static::$planId = static::$stripePrefix.'monthly-10-'.Str::random(10);
+        static::$otherPlanId = static::$stripePrefix.'monthly-10-'.Str::random(10);
+        static::$premiumPlanId = static::$stripePrefix.'monthly-20-premium-'.Str::random(10);
+        static::$couponId = static::$stripePrefix.'coupon-' . Str::random(10);
 
         Product::create([
             'id' => static::$productId,
@@ -279,7 +279,7 @@ class CashierTest extends TestCase
         try {
             $user->newSubscription('main', static::$planId)->create($this->getInvalidCardToken());
 
-            $this->fail('Expected exception ' . SubscriptionCreationFailed::class . ' was not thrown.');
+            $this->fail('Expected exception '.SubscriptionCreationFailed::class.' was not thrown.');
         } catch (SubscriptionCreationFailed $e) {
             // Assert no subscription was added to the billable entity.
             $this->assertEmpty($user->subscriptions);


### PR DESCRIPTION
Added a prorate() function to Subscription in order to re-enable the proration after it was disabled by calling noProrate().

Fixes #647