### PR TITLE
[9.0] Don't try and find a user when stripeId is null

### DIFF
--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -177,7 +177,7 @@ class WebhookController extends Controller
      */
     protected function getUserByStripeId($stripeId)
     {
-        if ($stripeId == null) {
+        if ($stripeId === null) {
             return;
         }
 

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -177,6 +177,10 @@ class WebhookController extends Controller
      */
     protected function getUserByStripeId($stripeId)
     {
+        if ($stripeId == null) {
+            return;
+        }
+
         $model = Cashier::stripeModel();
 
         return (new $model)->where('stripe_id', $stripeId)->first();


### PR DESCRIPTION
If a payment is manually created from the Stripe dashboard, it is
possible that it will not be linked to a customer.

When this null stripeId is used to find a user record, it will find the
first customer record that does not have a stripeId in the database.

Adding an early exit will prevent this from happening, and stop these
null stripeId users being erroneously referenced in webhook handling.