### PR TITLE
[10.0] Allow custom filename for invoice download

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -286,11 +286,23 @@ class Invoice
      */
     public function download(array $data)
     {
-        $filename = $data['product'].'_'.$this->date()->month.'_'.$this->date()->year.'.pdf';
+        $filename = $data['product'].'_'.$this->date()->month.'_'.$this->date()->year;
 
+        return $this->downloadAs($filename, $data);
+    }
+
+    /**
+     * Create an invoice download response with a specific filename.
+     *
+     * @param  string  $filename
+     * @param  array  $data
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function downloadAs($filename, array $data)
+    {
         return new Response($this->pdf($data), 200, [
             'Content-Description' => 'File Transfer',
-            'Content-Disposition' => 'attachment; filename="'.$filename.'"',
+            'Content-Disposition' => 'attachment; filename="'.$filename.'.pdf"',
             'Content-Transfer-Encoding' => 'binary',
             'Content-Type' => 'application/pdf',
         ]);


### PR DESCRIPTION
Allows people to use a custom filename when downloading invoices. Works a little bit nicer then overwriting the headers.

Closes https://github.com/laravel/cashier/issues/715