### PR TITLE
[10.0] Add indexes to those columns used to lookup data in the database

### DIFF
--- a/database/migrations/2019_05_03_000001_create_customer_columns.php
+++ b/database/migrations/2019_05_03_000001_create_customer_columns.php
@@ -14,7 +14,7 @@ class CreateCustomerColumns extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('stripe_id')->nullable()->collation('utf8mb4_bin');
+            $table->string('stripe_id')->nullable()->collation('utf8mb4_bin')->index();
             $table->string('card_brand')->nullable();
             $table->string('card_last_four', 4)->nullable();
             $table->timestamp('trial_ends_at')->nullable();

--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -15,10 +15,10 @@ class CreateSubscriptionsTable extends Migration
     {
         Schema::create('subscriptions', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('user_id')->index();
             $table->string('name');
             $table->string('stripe_id')->collation('utf8mb4_bin');
-            $table->string('stripe_status');
+            $table->string('stripe_status')->index();
             $table->string('stripe_plan');
             $table->integer('quantity');
             $table->timestamp('trial_ends_at')->nullable();


### PR DESCRIPTION
Digging into the code I see that `users.stripe_id` and `subscriptions.stripe_status` are both used in the query builder to query data in the database. Additionally, `subscriptions.user_id` is used to load the relationship between users and subscriptions.

I can't see why you wouldn't want these rows to be indexed for faster lookups, especially with big datasets.