### PR TITLE
[10.0] syncStripeStatus trying to update incorrect status column

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -159,7 +159,7 @@ class Subscription extends Model
     {
         $subscription = $this->asStripeSubscription();
 
-        $this->status = $subscription->status;
+        $this->stripe_status = $subscription->status;
 
         $this->save();
     }


### PR DESCRIPTION
syncStripeStatus method from Subscription model trying to update `status` column which is not correct. Correct column name is `stripe_status`.

