### PR TITLE
[10.0] Update Stripe API version

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -15,7 +15,7 @@ class Cashier
      *
      * @var string
      */
-    const STRIPE_VERSION = '2019-05-16';
+    const STRIPE_VERSION = '2019-08-14';
 
     /**
      * The custom currency formatter.


### PR DESCRIPTION
Since there are [no changes that affect Cashier](https://stripe.com/docs/upgrades?since=2019-05-16#api-changelog) we could use the latest Stripe API version (2019-08-14).
