### PR TITLE
[10.0] Set Stripe library info

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -11,6 +11,13 @@ use Money\Formatter\IntlMoneyFormatter;
 class Cashier
 {
     /**
+     * The Cashier library version.
+     *
+     * @var string
+     */
+    const VERSION = '10.0.0';
+
+    /**
      * The Stripe API version.
      *
      * @var string

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier;
 
+use Stripe\Stripe;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
@@ -18,6 +19,12 @@ class CashierServiceProvider extends ServiceProvider
         $this->registerResources();
         $this->registerMigrations();
         $this->registerPublishing();
+
+        Stripe::setAppInfo(
+            'Laravel Cashier',
+            Cashier::VERSION,
+            'https://laravel.com'
+        );
     }
 
     /**


### PR DESCRIPTION
This sets the Stripe App info as detailed in https://stripe.com/docs/building-plugins#setappinfo

This makes sure Stripe can identify Cashier as a library and can contact us when critical updates to the API are made.