### PR TITLE
[10.0] Remove collation from migrations

### DIFF
--- a/database/migrations/2019_05_03_000001_create_customer_columns.php
+++ b/database/migrations/2019_05_03_000001_create_customer_columns.php
@@ -14,7 +14,7 @@ class CreateCustomerColumns extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('stripe_id')->nullable()->collation('utf8mb4_bin')->index();
+            $table->string('stripe_id')->nullable()->index();
             $table->string('card_brand')->nullable();
             $table->string('card_last_four', 4)->nullable();
             $table->timestamp('trial_ends_at')->nullable();

--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -17,7 +17,7 @@ class CreateSubscriptionsTable extends Migration
             $table->bigIncrements('id');
             $table->unsignedBigInteger('user_id');
             $table->string('name');
-            $table->string('stripe_id')->collation('utf8mb4_bin');
+            $table->string('stripe_id');
             $table->string('stripe_status');
             $table->string('stripe_plan');
             $table->integer('quantity');


### PR DESCRIPTION
The reason for this is that the current collation is MySQL specific and doesn't works in other databases (like Postgres). This is still recommended by Stripe but maybe a note in the docs for this will suffice.

Fixes https://github.com/laravel/cashier/issues/747
