### PR TITLE
Only mount card element if payment has not succeeded or been cancelled

### DIFF
--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -107,12 +107,14 @@
                 errorMessage: ''
             },
 
-            mounted: function () {
-                const elements = stripe.elements();
+            @if (! $payment->isSucceeded() && ! $payment->isCancelled())
+                mounted: function () {
+                    const elements = stripe.elements();
 
-                this.cardElement = elements.create('card');
-                this.cardElement.mount('#card-element');
-            },
+                    this.cardElement = elements.create('card');
+                    this.cardElement.mount('#card-element');
+                },
+            @endif
 
             methods: {
                 confirmPayment: function () {


### PR DESCRIPTION
If the user refreshes the page after successfully paying there will be no `#card-element` to mount to. Equally a cancelled payment requires no card payment. This means we should only mount the card element if payment has not succeeded or been cancelled.