### PR TITLE
Ensure SVG icons are visible even with a long success or error message

### DIFF
--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -21,7 +21,7 @@
                     <path class="fill-current text-red-500" d="M12 18a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm1-5.9c-.13 1.2-1.88 1.2-2 0l-.5-5a1 1 0 0 1 1-1.1h1a1 1 0 0 1 1 1.1l-.5 5z"/>
                 </svg>
 
-                <span class="ml-3">@{{ errorMessage }}</span>
+                <span class="max-w-sm ml-3">@{{ errorMessage }}</span>
             </p>
 
             <p class="flex items-center mb-4 bg-green-100 border border-green-200 px-5 py-4 rounded-lg text-green-700" v-if="paymentProcessed && successMessage">
@@ -30,7 +30,7 @@
                     <path class="fill-current text-green-500" d="M10 14.59l6.3-6.3a1 1 0 0 1 1.4 1.42l-7 7a1 1 0 0 1-1.4 0l-3-3a1 1 0 0 1 1.4-1.42l2.3 2.3z"/>
                 </svg>
 
-                <span class="ml-3">@{{ successMessage }}</span>
+                <span class="max-w-sm ml-3">@{{ successMessage }}</span>
             </p>
 
             <div class="bg-white rounded-lg shadow-xl p-4 sm:py-6 sm:px-10 mb-5">


### PR DESCRIPTION
Before:

<img width="324" alt="before" src="https://user-images.githubusercontent.com/1266205/64247503-f04f6800-cf06-11e9-94ca-48ae6de9334a.png">

After (with a [`max-width`](https://tailwindcss.com/docs/max-width/) applied to the `span` that holds the success or error message):

<img width="324" alt="after" src="https://user-images.githubusercontent.com/1266205/64247838-97cc9a80-cf07-11e9-873c-8a908eb37248.png">

---

ℹ️ Even with this change, the SVG icon will still differ in size depending on the length of the success or error message. An alternative to this approach would be to add a [`min-width`](https://tailwindcss.com/docs/min-width/) to the SVG icon container but Tailwind doesn't offer appropriate values out of the box.