### PR TITLE
remove nullable() from 'stripe_status'

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -80,7 +80,7 @@ A new `stripe_status` database column has been introduced for the `subscriptions
 
 ```php
 Schema::table('subscriptions', function (Blueprint $table) {
-    $table->string('stripe_status')->nullable();
+    $table->string('stripe_status');
 });
 ```
 


### PR DESCRIPTION
removed nullable() from this guide to make it match the outcome of running the command 

`php artisan vendor:publish --tag="cashier-migrations"`

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
