### PR TITLE
[10.x] Update Stripe SDK to v7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.lock
 phpunit.xml
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/view": "~5.8.0|^6.0|^7.0",
         "moneyphp/money": "^3.2",
         "nesbot/carbon": "^2.0",
-        "stripe/stripe-php": "^6.40",
+        "stripe/stripe-php": "^7.0",
         "symfony/http-kernel": "^4.3",
         "symfony/intl": "^4.3"
     },

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -279,11 +279,6 @@ trait Billable
             $stripeInvoice = StripeInvoice::retrieve(
                 $id, $this->stripeOptions()
             );
-
-            $stripeInvoice->lines = StripeInvoice::retrieve($id, $this->stripeOptions())
-                        ->lines
-                        ->all(['limit' => 1000]);
-
             return new Invoice($this, $stripeInvoice);
         } catch (Exception $exception) {
             //

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -279,6 +279,7 @@ trait Billable
             $stripeInvoice = StripeInvoice::retrieve(
                 $id, $this->stripeOptions()
             );
+
             return new Invoice($this, $stripeInvoice);
         } catch (Exception $exception) {
             //
@@ -446,23 +447,14 @@ trait Billable
             return;
         }
 
-        $stripePaymentMethod->detach(null, $this->stripeOptions());
-
         $customer = $this->asStripeCustomer();
 
         $defaultPaymentMethod = $customer->invoice_settings->default_payment_method;
 
-        // If payment method was the default payment method, we'll remove it manually...
+        $stripePaymentMethod->detach(null, $this->stripeOptions());
+
+        // If the payment method was the default payment method, we'll remove it manually...
         if ($stripePaymentMethod->id === $defaultPaymentMethod) {
-            $customer->invoice_settings = ['default_payment_method' => null];
-
-            $customer->save($this->stripeOptions());
-
-            $defaultPaymentMethod = null;
-        }
-
-        // If the default payment was already removed, we'll just update the database...
-        if (is_null($defaultPaymentMethod)) {
             $this->forceFill([
                 'card_brand' => null,
                 'card_last_four' => null,

--- a/src/Http/Middleware/VerifyWebhookSignature.php
+++ b/src/Http/Middleware/VerifyWebhookSignature.php
@@ -5,7 +5,7 @@ namespace Laravel\Cashier\Http\Middleware;
 use Closure;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Foundation\Application;
-use Stripe\Error\SignatureVerification;
+use Stripe\Exception\SignatureVerificationException;
 use Stripe\WebhookSignature;
 
 class VerifyWebhookSignature
@@ -53,7 +53,7 @@ class VerifyWebhookSignature
                 $this->config->get('cashier.webhook.secret'),
                 $this->config->get('cashier.webhook.tolerance')
             );
-        } catch (SignatureVerification $exception) {
+        } catch (SignatureVerificationException $exception) {
             $this->app->abort(403);
         }
 

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -234,7 +234,7 @@ class Invoice
         }
 
         return $this->items->filter(function (StripeInvoiceLineItem $item) use ($type) {
-            return $item->type == $type;
+            return $item->type === $type;
         })->map(function (StripeInvoiceLineItem $item) {
             return new InvoiceItem($this->owner, $item);
         })->all();

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model as Eloquent;
 use Laravel\Cashier\Tests\Fixtures\User;
 use Laravel\Cashier\Tests\TestCase;
 use Stripe\ApiResource;
-use Stripe\Error\InvalidRequest;
+use Stripe\Exception\InvalidRequestException;
 use Stripe\Stripe;
 
 abstract class IntegrationTestCase extends TestCase
@@ -38,7 +38,7 @@ abstract class IntegrationTestCase extends TestCase
     {
         try {
             $resource->delete();
-        } catch (InvalidRequest $e) {
+        } catch (InvalidRequestException $e) {
             //
         }
     }


### PR DESCRIPTION
The changes from v6 to v7 seem trivial to me, so I think this can be merged into Casher v10.

## Update Stripe SDK to v7
- Replace `Charge::refund()` to `Refund::create()`
- Replace `Customer::invoices()` to `Invoice::all()`
- Replace renamed exception classes

## Fix removing default payment method
After upgrading to the v7 of the Stripe SDK, the `$customer->invoice_settings->default_payment_method` is null.

In that case, we don't need to update the Stripe customer, so we will just update the database.

The previous functionality has been kept as is.

## Lazy-load the invoice line items
According to #562, the invoice response contains only 10 line items, so we were manually fetching 1000 items.

But Stripe's pagination limit is 100 items, so that doesn't ensure that all the line items will be fetched.

Instead, we can use the `Stripe\Collection::autoPagingIterator()` which automatically fetches all the paginated results with a generator.

I was tempted to use a lazy collection here, but since this method will be called by the `Invoice::invoiceItems()` and `Invoice::subscriptions()` methods, we don't want to hit the API twice just to filter the results.