### PR TITLE
[10.x] Add possibility to complete an order

### DIFF
--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -85,7 +85,6 @@
                                 {{ __('Your payment was correctly processed. Please click on the button below to continue with your order.') }}
                             </p>
                             <form action="{{ $next }}" method="post">
-                                @csrf
                                 <button
                                     type="submit"
                                     class="inline-block w-full px-4 py-3 mb-4 text-white rounded-lg hover:bg-blue-500 bg-blue-600"

--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -78,6 +78,23 @@
                             {{ __('Pay :amount', ['amount' => $payment->amount()]) }}
                         </button>
                     </div>
+
+                    @if ($next)
+                        <div v-else>
+                            <p class="mb-6 text-blue-600">
+                                {{ __('Your payment was correctly processed. Please click on the button below to continue with your order.') }}
+                            </p>
+                            <form action="{{ $next }}" method="post">
+                                @csrf
+                                <button
+                                    type="submit"
+                                    class="inline-block w-full px-4 py-3 mb-4 text-white rounded-lg hover:bg-blue-500 bg-blue-600"
+                                >
+                                    {{ __('Complete Order') }}
+                                </button>
+                            </form>
+                        </div>
+                    @endif
                 @endif
 
                 <a href="{{ $redirect ?? url('/') }}"

--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -23,6 +23,7 @@ class PaymentController extends Controller
                 StripePaymentIntent::retrieve($id, Cashier::stripeOptions())
             ),
             'redirect' => request('redirect'),
+            'next' => request('next'),
         ]);
     }
 }


### PR DESCRIPTION
This is my first ever pull request to a Laravel package, sorry if I'm making mistakes 😄

I was kind of surprise no one asked about it, so I decided to open a PR.

I've already updated 3 client projects (for SCA) that use Laravel Cashier to handle Single Charges. Those charge occur every time in the process of creating and complete an **order**.

This is a very basic example of how an order was paid and completed before SCA:

```php
class OrderController extends Controller
{
    public function store(Request $request)
    {
        $order = Order::create($whateverData);

        auth()->user()->charge($price);

        // if we get here then the charge was successful, we can continue
        $order->completed = true;
        $order->save();

        return redirect()->route('order.confirmation.show', $order);
    }
}
```

Now, with the `IncompletePayment` exception, the same code will look like that:

```php
class OrderController extends Controller
{
    public function store(Request $request)
    {
        $order = Order::create($whateverData);

        try {
            auth()->user()->charge($price);
        } catch (IncompletePayment $exception) {
            // if we get here then the charge needs additional step, and thus the code to complete the order can never be executed
            return redirect()->route(
                'cashier.payment',
                [$exception->payment->id, 'redirect' => route('product.show')]
            );
        }

        // if we get here then the charge was successful, we can continue
        $order->completed = true;
        $order->save();

        // trigger OrderCompleted notification, job etc.

        return redirect()->route('order.confirmation.show', $order);
    }
}
```

I really appreciate the way we can redirect ourselves to the cashier payment page, it allows us to pass any additional data we might need.

In the cases I encountered, I had to pass a new redirect parameter to the payment page, **every time**.

In order to complete the order, I had to create a new controller that only handles the completion of the order:

```php
class OrderConfirmationController extends Controller
{
    public function store(Request $request, Order $order)
    {
        // this code had to be duplicated from OrderController@store so that it can be triggered
        $order->completed = true;
        $order->save();

        // trigger OrderCompleted notification, job etc.

        return redirect()->route('order.confirmation.show', $order);
    }
}
```

And in order to trigger this code, I needed to simply redirect the user there once the payment was successful on the cashier page.

This is why I added a `<div v-else>` section in the layout, with a simple form and button for the user to click and complete the order.

In this PR I wrapped the v-else in a `@if ($next) @endif` so that it is not mandatory, but developers will be able to show a button to continue to the next step of the order processing flow.

Right now we only have one redirect button that is displayed at any time on the page, but it is only for the user to **go back**, either because the payment failed or not, which is a bit confusing because after the payment is successful, the only option for the user is to go back to a default page.

Note that in those projects, we only handle single charges, we don't use subscription and / or stripe webhooks.

I hope it makes sense!

Also, I'm not sure how to test this.