### PR TITLE
Configure Stripe logger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "illuminate/contracts": "~5.8.0|^6.0|^7.0",
         "illuminate/database": "~5.8.0|^6.0|^7.0",
         "illuminate/http": "~5.8.0|^6.0|^7.0",
+        "illuminate/log": "~5.8.0|^6.0|^7.0",
         "illuminate/notifications": "~5.8.0|^6.0|^7.0",
         "illuminate/routing": "~5.8.0|^6.0|^7.0",
         "illuminate/support": "~5.8.0|^6.0|^7.0",

--- a/config/cashier.php
+++ b/config/cashier.php
@@ -113,4 +113,17 @@ return [
 
     'paper' => env('CASHIER_PAPER', 'letter'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Stripe Logger
+    |--------------------------------------------------------------------------
+    |
+    | This setting defines which logging channel will be used by the Stripe
+    | library to write log messages. For example, "default" will use the
+    | application's default log. Otherwise, "error_log" will be used.
+    |
+    */
+
+    'logger' => env('CASHIER_LOGGER'),
+
 ];

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -46,6 +46,13 @@ class Cashier
     public static $registersRoutes = true;
 
     /**
+     * Indicates the logging channel used by the Stripe library.
+     *
+     * @var string|null
+     */
+    public static $logger = null;
+
+    /**
      * Get the default Stripe API options.
      *
      * @param  array  $options
@@ -111,6 +118,19 @@ class Cashier
     public static function ignoreRoutes()
     {
         static::$registersRoutes = false;
+
+        return new static;
+    }
+
+    /**
+     * Configure Stripe to use a logging channel.
+     *
+     * @param  string|null  $logger
+     * @return static
+     */
+    public static function useLogger($logger)
+    {
+        static::$logger = $logger;
 
         return new static;
     }

--- a/src/CashierServiceProvider.php
+++ b/src/CashierServiceProvider.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Stripe\Stripe;
+use Stripe\Util\LoggerInterface;
 
 class CashierServiceProvider extends ServiceProvider
 {
@@ -15,6 +16,7 @@ class CashierServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->registerLogger();
         $this->registerRoutes();
         $this->registerResources();
         $this->registerMigrations();
@@ -35,6 +37,7 @@ class CashierServiceProvider extends ServiceProvider
     public function register()
     {
         $this->configure();
+        $this->bindLogger();
     }
 
     /**
@@ -47,6 +50,34 @@ class CashierServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             __DIR__.'/../config/cashier.php', 'cashier'
         );
+    }
+
+    /**
+     * Bind the Stripe logger interface to the Cashier logger.
+     *
+     * @return void
+     */
+    protected function bindLogger()
+    {
+        $this->app->bind(LoggerInterface::class, function ($app) {
+            return new Logger($app->make('log')->channel(Cashier::$logger));
+        });
+    }
+
+    /**
+     * Register the Stripe logger.
+     *
+     * @return void
+     */
+    protected function registerLogger()
+    {
+        if ($logger = config('cashier.logger')) {
+            Cashier::useLogger($logger);
+        }
+
+        if (Cashier::$logger) {
+            Stripe::setLogger($this->app->make(LoggerInterface::class));
+        }
     }
 
     /**

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Laravel\Cashier;
+
+use Psr\Log\LoggerInterface;
+use Stripe\Util\LoggerInterface as StripeLogger;
+
+class Logger implements StripeLogger
+{
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function error($message, array $context = [])
+    {
+        $this->logger->error($message, $context);
+    }
+};

--- a/tests/Unit/LoggerTest.php
+++ b/tests/Unit/LoggerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Unit;
+
+use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Logger;
+use Laravel\Cashier\Tests\TestCase;
+use Mockery as m;
+use Psr\Log\LoggerInterface as PsrLoggerInterface;
+use Stripe\Stripe;
+use Stripe\Util\DefaultLogger;
+use Stripe\Util\LoggerInterface;
+
+class LoggerTest extends TestCase
+{
+    /** @var string|null */
+    protected $channel;
+
+    public function test_the_logger_is_correctly_bound()
+    {
+        $logger = $this->app->make(LoggerInterface::class);
+
+        $this->assertInstanceOf(
+            Logger::class,
+            $logger,
+            'Failed asserting that the Stripe logger interface is bound to the Cashier logger.'
+        );
+
+        $this->assertInstanceOf(
+            LoggerInterface::class,
+            $logger,
+            'Failed asserting that the Cashier logger implements the Stripe logger interface.'
+        );
+    }
+
+    public function test_the_logger_uses_a_log_channel()
+    {
+        $channel = m::mock(PsrLoggerInterface::class);
+        $channel->shouldReceive('error')->once()->with('foo', ['bar']);
+
+        $this->mock('log', function ($logger) use ($channel) {
+            $logger->shouldReceive('channel')->with('default')->once()->andReturn($channel);
+        });
+
+        Cashier::useLogger('default');
+
+        $logger = $this->app->make(LoggerInterface::class);
+
+        $logger->error('foo', ['bar']);
+
+        Cashier::useLogger(null);
+    }
+
+    public function test_it_uses_the_default_stripe_logger()
+    {
+        $logger = Stripe::getLogger();
+
+        $this->assertInstanceOf(
+            DefaultLogger::class,
+            $logger,
+            'Failed asserting that Stripe uses its own logger.'
+        );
+    }
+
+    public function test_it_uses_a_configured_logger()
+    {
+        $this->channel = 'default';
+
+        $this->refreshApplication();
+
+        $logger = Stripe::getLogger();
+
+        $this->assertInstanceOf(
+            Logger::class,
+            $logger,
+            'Failed asserting that Stripe uses the Cashier logger.'
+        );
+    }
+
+    public function test_it_uses_a_registered_logger()
+    {
+        Cashier::useLogger('default');
+
+        $this->refreshApplication();
+
+        $logger = Stripe::getLogger();
+
+        $this->assertInstanceOf(
+            Logger::class,
+            $logger,
+            'Failed asserting that Stripe uses the Cashier logger.'
+        );
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('cashier.logger', $this->channel);
+    }
+}


### PR DESCRIPTION
### Allow users to configure the Stripe library logger using Laravel's logging channels.

By default the Stripe library uses a subset of the PSR-3 logger interface to writes log messages using `error_log`.

This feature gives users the ability to use Laravel's logging channels instead, by decorating them in a `Laravel\Cashier\Logger` class, which implements Stripe's logging interface. For more advanced cases, the decorator can accept any PSR-3 implementation.

We can define the desired logging channel name in 3 ways:

**1. Using the `CASHIER_LOGGER` variable in the .env file.**

```
CASHIER_LOGGER=default
```

**2. Otherwise the `cashier.logger` configuration value can be overriden in the published `cashier.php`:**

```php
'logger' => 'default',
```

**3. Or by calling `Cashier::useLogger()` in the `register` method of a service provider:**

```php
Cashier::useLogger('default');
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
