### PR TITLE
[10.x] Mark asStripe... methods internal

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -756,6 +756,7 @@ trait Billable
     /**
      * Get the Stripe customer for the model.
      *
+     * @internal
      * @return \Stripe\Customer
      */
     public function asStripeCustomer()

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -320,6 +320,7 @@ class Invoice
     /**
      * Get the Stripe invoice instance.
      *
+     * @internal
      * @return \Stripe\Invoice
      */
     public function asStripeInvoice()

--- a/src/InvoiceItem.php
+++ b/src/InvoiceItem.php
@@ -115,6 +115,7 @@ class InvoiceItem
     /**
      * Get the underlying Stripe invoice item.
      *
+     * @internal
      * @return \Stripe\StripeObject
      */
     public function asStripeInvoiceItem()

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -116,6 +116,7 @@ class Payment
     /**
      * The Stripe PaymentIntent instance.
      *
+     * @internal
      * @return \Stripe\PaymentIntent
      */
     public function asStripePaymentIntent()

--- a/src/PaymentMethod.php
+++ b/src/PaymentMethod.php
@@ -46,6 +46,7 @@ class PaymentMethod
     /**
      * Get the Stripe PaymentMethod instance.
      *
+     * @internal
      * @return \Stripe\PaymentMethod
      */
     public function asStripePaymentMethod()

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -663,6 +663,7 @@ class Subscription extends Model
     /**
      * Get the subscription as a Stripe subscription object.
      *
+     * @internal
      * @param  array  $expand
      * @return \Stripe\Subscription
      */


### PR DESCRIPTION
Based on [this comment](https://github.com/laravel/cashier/issues/794#issuecomment-540620215) objects returned by the asStripe.. methods should not be considered part of the public api so it should be marked as internal to notify developers.