### PR TITLE
[10.x] Allow custom mail building and redirection url in payment notification

### DIFF
--- a/src/Notifications/ConfirmPayment.php
+++ b/src/Notifications/ConfirmPayment.php
@@ -13,6 +13,13 @@ class ConfirmPayment extends Notification implements ShouldQueue
     use Queueable;
 
     /**
+     * The callback that should be used to build the mail message.
+     *
+     * @var \Closure|null
+     */
+    public static $toMailCallback;
+
+    /**
      * The PaymentIntent identifier.
      *
      * @var string
@@ -59,6 +66,10 @@ class ConfirmPayment extends Notification implements ShouldQueue
     {
         $url = $this->paymentUrl($notifiable);
 
+        if(static::$toMailCallback){
+            return (static::$toMailCallback)($this->amount, $url);
+        }
+
         return (new MailMessage)
             ->greeting(__('Confirm your :amount payment', ['amount' => $this->amount]))
             ->line(__('Extra confirmation is needed to process your payment. Please continue to the payment page by clicking on the button below.'))
@@ -74,5 +85,16 @@ class ConfirmPayment extends Notification implements ShouldQueue
     protected function paymentUrl($notifiable)
     {
         return route('cashier.payment', ['id' => $this->paymentId]);
+    }
+
+    /**
+     * Set a callback that should be used when building the notification mail message.
+     *
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function toMailUsing($callback)
+    {
+        static::$toMailCallback = $callback;
     }
 }

--- a/src/Notifications/ConfirmPayment.php
+++ b/src/Notifications/ConfirmPayment.php
@@ -57,11 +57,22 @@ class ConfirmPayment extends Notification implements ShouldQueue
      */
     public function toMail($notifiable)
     {
-        $url = route('cashier.payment', ['id' => $this->paymentId]);
+        $url = $this->paymentUrl($notifiable);
 
         return (new MailMessage)
             ->greeting(__('Confirm your :amount payment', ['amount' => $this->amount]))
             ->line(__('Extra confirmation is needed to process your payment. Please continue to the payment page by clicking on the button below.'))
             ->action(__('Confirm Payment'), $url);
+    }
+
+    /**
+     * Get the payment verification URL for the given notifiable.
+     *
+     * @param  mixed  $notifiable
+     * @return string
+     */
+    protected function paymentUrl($notifiable)
+    {
+        return route('cashier.payment', ['id' => $this->paymentId]);
     }
 }

--- a/src/Notifications/ConfirmPayment.php
+++ b/src/Notifications/ConfirmPayment.php
@@ -74,7 +74,7 @@ class ConfirmPayment extends Notification implements ShouldQueue
         $url = $this->paymentUrl($notifiable);
 
         if (static::$toMailCallback) {
-            return (static::$toMailCallback)($this->amount, $url);
+            return (static::$toMailCallback)($notifiable, $this->amount, $url);
         }
 
         return (new MailMessage)


### PR DESCRIPTION
This pull request extends the payment notification with two features:
- It allows defining a callback to build the mailable just like the VerifyEmail and ResetPassword notification
- It allows defining an URL or a callback to provide a redirection URL after the confirmation page
- It also splits out the payment URL generation for easier overriding in case if needed.

This pull request does not change the default behavior and is totally backward compatible so Im sending it against 10.x