### PR TITLE
[10.x] Add findPaymentMethod method

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -279,11 +279,11 @@ trait Billable
             $stripeInvoice = StripeInvoice::retrieve(
                 $id, $this->stripeOptions()
             );
-
-            return new Invoice($this, $stripeInvoice);
         } catch (Exception $exception) {
             //
         }
+
+        return new Invoice($this, $stripeInvoice);
     }
 
     /**
@@ -602,6 +602,23 @@ trait Billable
         });
 
         $this->updateDefaultPaymentMethodFromStripe();
+    }
+
+    /**
+     * Find a PaymentMethod by ID.
+     *
+     * @param  string  $paymentMethod
+     * @return \Laravel\Cashier\PaymentMethod
+     */
+    public function findPaymentMethod($paymentMethod)
+    {
+        try {
+            $stripePaymentMethod = $this->resolveStripePaymentMethod($paymentMethod);
+        } catch (Exception $exception) {
+            //
+        }
+
+        return new PaymentMethod($this, $stripePaymentMethod);
     }
 
     /**

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier;
 
 use Carbon\Carbon;
 use Dompdf\Dompdf;
+use Exception;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\View;
 use Stripe\Invoice as StripeInvoice;
@@ -42,6 +43,10 @@ class Invoice
      */
     public function __construct($owner, StripeInvoice $invoice)
     {
+        if ($owner->stripe_id !== $invoice->customer) {
+            throw new Exception("The invoice `{$invoice->id}` does not belong to this customer `$owner->stripe_id`.");
+        }
+
         $this->owner = $owner;
         $this->invoice = $invoice;
     }

--- a/src/InvoiceItem.php
+++ b/src/InvoiceItem.php
@@ -24,7 +24,7 @@ class InvoiceItem
      * Create a new invoice item instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $owner
-     * @param  \Stripe\StripeObject  $item
+     * @param  \Stripe\InvoiceLineItem  $item
      * @return void
      */
     public function __construct($owner, $item)

--- a/src/PaymentMethod.php
+++ b/src/PaymentMethod.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier;
 
+use Exception;
 use Stripe\PaymentMethod as StripePaymentMethod;
 
 class PaymentMethod
@@ -29,6 +30,10 @@ class PaymentMethod
      */
     public function __construct($owner, StripePaymentMethod $paymentMethod)
     {
+        if ($owner->stripe_id !== $paymentMethod->customer) {
+            throw new Exception("The invoice `{$paymentMethod->id}` does not belong to this customer `$owner->stripe_id`.");
+        }
+
         $this->owner = $owner;
         $this->paymentMethod = $paymentMethod;
     }


### PR DESCRIPTION
Replacement for https://github.com/laravel/cashier/pull/800

Adds a new `findPaymentMethod` method to the Billable entity. Also adds a check in the `Invoice` and `PaymentMethod` object's constructors to make sure that no invalid objects can be build.

Pulled out the constructing of the objects outside the retrieval of the stripe object's try/catch blocks so these new exceptions can cascade through.