### PR TITLE
[10.x] Allow to set past due as active

### DIFF
--- a/config/cashier.php
+++ b/config/cashier.php
@@ -126,4 +126,17 @@ return [
 
     'logger' => env('CASHIER_LOGGER'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Deactivate Past Due Subscriptions
+    |--------------------------------------------------------------------------
+    |
+    | By default, subscriptions with a "past due" state will be treated
+    | as inactive. You can choose to change this behavior by setting
+    | the configuration below to false so that they remain active.
+    |
+    */
+
+    'deactivate_past_due' => true,
+
 ];

--- a/config/cashier.php
+++ b/config/cashier.php
@@ -126,17 +126,4 @@ return [
 
     'logger' => env('CASHIER_LOGGER'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Deactivate Past Due Subscriptions
-    |--------------------------------------------------------------------------
-    |
-    | By default, subscriptions with a "past due" state will be treated
-    | as inactive. You can choose to change this behavior by setting
-    | the configuration below to false so that they remain active.
-    |
-    */
-
-    'deactivate_past_due' => true,
-
 ];

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -123,11 +123,11 @@ class Cashier
     }
 
     /**
-     * Configure Cashier to mark past due subscriptions as active.
+     * Configure Cashier to maintain past due subscriptions as active.
      *
      * @return static
      */
-    public static function activatePastDue()
+    public static function keepPastDueSubscriptionsActive()
     {
         static::$deactivatePastDue = false;
 

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -46,6 +46,13 @@ class Cashier
     public static $registersRoutes = true;
 
     /**
+     * Indicates if Cashier will mark past due subscriptions as inactive.
+     *
+     * @var bool
+     */
+    public static $deactivatePastDue = true;
+
+    /**
      * Get the default Stripe API options.
      *
      * @param  array  $options
@@ -111,6 +118,18 @@ class Cashier
     public static function ignoreRoutes()
     {
         static::$registersRoutes = false;
+
+        return new static;
+    }
+
+    /**
+     * Configure Cashier to mark past due subscriptions as active.
+     *
+     * @return static
+     */
+    public static function activatePastDue()
+    {
+        static::$deactivatePastDue = false;
 
         return new static;
     }

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -124,12 +124,10 @@ class Subscription extends Model
      */
     public function active()
     {
-        $ignorePastDue = ! config('cashier.deactivate_past_due');
-
         return (is_null($this->ends_at) || $this->onGracePeriod()) &&
             $this->stripe_status !== StripeSubscription::STATUS_INCOMPLETE &&
             $this->stripe_status !== StripeSubscription::STATUS_INCOMPLETE_EXPIRED &&
-            ($ignorePastDue || $this->stripe_status !== StripeSubscription::STATUS_PAST_DUE) &&
+            (! Cashier::$deactivatePastDue || $this->stripe_status !== StripeSubscription::STATUS_PAST_DUE) &&
             $this->stripe_status !== StripeSubscription::STATUS_UNPAID;
     }
 
@@ -150,7 +148,7 @@ class Subscription extends Model
             ->where('stripe_status', '!=', StripeSubscription::STATUS_INCOMPLETE_EXPIRED)
             ->where('stripe_status', '!=', StripeSubscription::STATUS_UNPAID);
 
-        if (config('cashier.deactivate_past_due')) {
+        if (Cashier::$deactivatePastDue) {
             $query->where('stripe_status', '!=', StripeSubscription::STATUS_PAST_DUE);
         }
     }

--- a/tests/Integration/SubscriptionsTest.php
+++ b/tests/Integration/SubscriptionsTest.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier\Tests\Integration;
 use Carbon\Carbon;
 use DateTime;
 use Illuminate\Support\Str;
+use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Exceptions\PaymentActionRequired;
 use Laravel\Cashier\Exceptions\PaymentFailure;
 use Laravel\Cashier\Payment;
@@ -562,14 +563,15 @@ class SubscriptionsTest extends IntegrationTestCase
         $this->assertFalse($subscription->active());
         $this->assertFalse($user->subscriptions()->active()->exists());
 
-        config(['cashier.deactivate_past_due' => false]);
+        Cashier::activatePastDue();
 
         $subscription->update(['ends_at' => null, 'stripe_status' => StripeSubscription::STATUS_PAST_DUE]);
 
         $this->assertTrue($subscription->active());
         $this->assertTrue($user->subscriptions()->active()->exists());
 
-        config(['cashier.deactivate_past_due' => true]);
+        // Reset deactivate past due state to default to not conflict with other tests.
+        Cashier::$deactivatePastDue = true;
     }
 
     public function test_retrieve_the_latest_payment_for_a_subscription()


### PR DESCRIPTION
This will add the ability to set past due subscriptions as active instead of the default inactive status. This will allow past due subscriptions to remain active until they're finally cancelled. 

Closes https://github.com/laravel/cashier/issues/768