### PR TITLE
[10.x] Webhook events

### DIFF
--- a/src/Events/WebhookHandled.php
+++ b/src/Events/WebhookHandled.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\Cashier\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 
 class WebhookHandled
 {

--- a/src/Events/WebhookHandled.php
+++ b/src/Events/WebhookHandled.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Cashier\Events;
+
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class WebhookHandled
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * The webhook payload.
+     *
+     * @var array
+     */
+    public $payload;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  array  $payload
+     * @return void
+     */
+    public function __construct(array $payload)
+    {
+        $this->payload = $payload;
+    }
+}

--- a/src/Events/WebhookReceived.php
+++ b/src/Events/WebhookReceived.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Cashier\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class WebhookReceived
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * The webhook payload.
+     *
+     * @var array
+     */
+    public $payload;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  array  $payload
+     * @return void
+     */
+    public function __construct(array $payload)
+    {
+        $this->payload = $payload;
+    }
+}

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -7,6 +7,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use Laravel\Cashier\Events\WebhookHandled;
 use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
 use Laravel\Cashier\Payment;
 use Laravel\Cashier\Subscription;
@@ -39,7 +40,9 @@ class WebhookController extends Controller
         $method = 'handle'.Str::studly(str_replace('.', '_', $payload['type']));
 
         if (method_exists($this, $method)) {
-            return $this->{$method}($payload);
+            $response = $this->{$method}($payload);
+            WebhookHandled::dispatch($payload);
+            return $response;
         }
 
         return $this->missingMethod();

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -42,6 +42,7 @@ class WebhookController extends Controller
         if (method_exists($this, $method)) {
             $response = $this->{$method}($payload);
             WebhookHandled::dispatch($payload);
+
             return $response;
         }
 

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Cashier\Events\WebhookHandled;
+use Laravel\Cashier\Events\WebhookReceived;
 use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
 use Laravel\Cashier\Payment;
 use Laravel\Cashier\Subscription;
@@ -39,8 +40,11 @@ class WebhookController extends Controller
         $payload = json_decode($request->getContent(), true);
         $method = 'handle'.Str::studly(str_replace('.', '_', $payload['type']));
 
+        WebhookReceived::dispatch($payload);
+
         if (method_exists($this, $method)) {
             $response = $this->{$method}($payload);
+
             WebhookHandled::dispatch($payload);
 
             return $response;

--- a/tests/Unit/WebhookControllerTest.php
+++ b/tests/Unit/WebhookControllerTest.php
@@ -16,7 +16,7 @@ class WebhookControllerTest extends TestCase
         $request = $this->request('charge.succeeded');
 
         Event::fake([
-            WebhookHandled::class
+            WebhookHandled::class,
         ]);
 
         $response = (new WebhookControllerTestStub)->handleWebhook($request);


### PR DESCRIPTION
New implementation for https://github.com/laravel/cashier/pull/804 with an extra `WebhookReceived` event. This way anyone can hook into any event that was received.