### PR TITLE
[9.0] Update .styleci.yml

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,8 @@
 php:
   preset: laravel
+  enabled:
+    - length_ordered_imports
+  disabled:
+    - alpha_ordered_imports
 js: true
 css: true


### PR DESCRIPTION
Alpha ordered imports will become the default for the laravel preset in a few minutes time on styleci.io.