### PR TITLE
[10.x] Add Missing @throws tags

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -184,6 +184,8 @@ class SubscriptionBuilder
      *
      * @param  array  $options
      * @return \Laravel\Cashier\Subscription
+     * @throws \Laravel\Cashier\Exceptions\PaymentActionRequired
+     * @throws \Laravel\Cashier\Exceptions\PaymentFailure
      */
     public function add(array $options = [])
     {
@@ -196,6 +198,8 @@ class SubscriptionBuilder
      * @param  \Stripe\PaymentMethod|string|null  $paymentMethod
      * @param  array  $options
      * @return \Laravel\Cashier\Subscription
+     * @throws \Laravel\Cashier\Exceptions\PaymentActionRequired
+     * @throws \Laravel\Cashier\Exceptions\PaymentFailure
      */
     public function create($paymentMethod = null, array $options = [])
     {
@@ -210,6 +214,7 @@ class SubscriptionBuilder
             $trialEndsAt = $this->trialExpires;
         }
 
+        /** @var \Laravel\Cashier\Subscription $subscription */
         $subscription = $this->owner->subscriptions()->create([
             'name' => $this->name,
             'stripe_id' => $stripeSubscription->id,


### PR DESCRIPTION
Adds missing PHPDocs `@throws` for `create`/`add` methods on `Laravel\Cashier\SubscriptionBuilder` class. 

This aligns with what is described in `Upgrading To 10.0 From 9.0`: https://github.com/laravel/cashier/blob/master/UPGRADE.md#new-exceptions 
