### PR TITLE
[10.x] Support default TaxRates for Subscriptions

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -791,13 +791,13 @@ trait Billable
     }
 
     /**
-     * Get the tax percentage to apply to the subscription.
+     * Get the tax rates to apply to the subscription.
      *
-     * @return int|float
+     * @return array
      */
-    public function taxPercentage()
+    public function taxRates()
     {
-        return 0;
+        return [];
     }
 
     /**

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -624,15 +624,15 @@ class Subscription extends Model
     }
 
     /**
-     * Sync the tax percentage of the user to the subscription.
+     * Sync the tax rates of the user to the subscription.
      *
      * @return void
      */
-    public function syncTaxPercentage()
+    public function syncTaxRates()
     {
         $subscription = $this->asStripeSubscription();
 
-        $subscription->tax_percent = $this->user->taxPercentage();
+        $subscription->default_tax_rates = $this->user->taxRates();
 
         $subscription->save();
     }

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -205,8 +205,9 @@ class SubscriptionBuilder
     {
         $customer = $this->getStripeCustomer($paymentMethod, $options);
 
-        /** @var \Stripe\Subscription $stripeSubscription */
-        $stripeSubscription = $customer->subscriptions->create($this->buildPayload());
+        $stripeSubscription = \Stripe\Subscription::create(
+            ['customer' => $customer->id] + $this->buildPayload()
+        );
 
         if ($this->skipTrial) {
             $trialEndsAt = null;
@@ -266,7 +267,7 @@ class SubscriptionBuilder
             'metadata' => $this->metadata,
             'plan' => $this->plan,
             'quantity' => $this->quantity,
-            'tax_percent' => $this->getTaxPercentageForPayload(),
+            'default_tax_rates' => $this->getTaxRatesForPayload(),
             'trial_end' => $this->getTrialEndForPayload(),
             'off_session' => true,
         ]);
@@ -289,14 +290,14 @@ class SubscriptionBuilder
     }
 
     /**
-     * Get the tax percentage for the Stripe payload.
+     * Get the tax rates for the Stripe payload.
      *
-     * @return int|float|null
+     * @return array|null
      */
-    protected function getTaxPercentageForPayload()
+    protected function getTaxRatesForPayload()
     {
-        if ($taxPercentage = $this->owner->taxPercentage()) {
-            return $taxPercentage;
+        if ($taxRates = $this->owner->taxRates()) {
+            return $taxRates;
         }
     }
 }


### PR DESCRIPTION
Hello, 

This is a small PR that removes the tax_percent parameter in a Subscription creation and replaces it by the new default_tax_rates.
The Billable Trait has been updated, the taxRates that replace taxPercentage method returns nothing too and can be overriden in the User Model to return a array of TaxRate ids.

I don't think that it's necessary to add a TaxRate class into Cashier for now but let me know what you think.