### PR TITLE
[11.x] Update to 2019-12-03 Stripe API version

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -22,7 +22,7 @@ class Cashier
      *
      * @var string
      */
-    const STRIPE_VERSION = '2019-08-14';
+    const STRIPE_VERSION = '2019-12-03';
 
     /**
      * The custom currency formatter.


### PR DESCRIPTION
Nothing directly affects Cashier. Upgrade notices can be found here: https://stripe.com/docs/upgrades