### PR TITLE
[10.x] Simplify refund method

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -62,10 +62,8 @@ trait Billable
      */
     public function refund($paymentIntent, array $options = [])
     {
-        $intent = StripePaymentIntent::retrieve($paymentIntent, $this->stripeOptions());
-
         return StripeRefund::create(
-            ['charge' => $intent->charges->data[0]->id] + $options,
+            ['payment_intent' => $paymentIntent] + $options,
             $this->stripeOptions()
         );
     }


### PR DESCRIPTION
Stripe has added the ability to simply pass a payment intend ID to the refund api so we don't have to retrieve it first. We can simplify the refund method internals with this change.

Closes https://github.com/laravel/cashier/issues/825