### PR TITLE
[11.x] Add new has payment method

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -380,13 +380,23 @@ trait Billable
     }
 
     /**
-     * Determines if the customer currently has a payment method.
+     * Determines if the customer currently has a default payment method.
+     *
+     * @return bool
+     */
+    public function hasDefaultPaymentMethod()
+    {
+        return (bool) $this->card_brand;
+    }
+
+    /**
+     * Determines if the customer currently has at least one payment method.
      *
      * @return bool
      */
     public function hasPaymentMethod()
     {
-        return (bool) $this->card_brand;
+        return $this->paymentMethods()->isNotEmpty();
     }
 
     /**

--- a/tests/Integration/PaymentMethodsTest.php
+++ b/tests/Integration/PaymentMethodsTest.php
@@ -28,6 +28,8 @@ class PaymentMethodsTest extends IntegrationTestCase
         $this->assertInstanceOf(PaymentMethod::class, $paymentMethod);
         $this->assertEquals('visa', $paymentMethod->card->brand);
         $this->assertEquals('4242', $paymentMethod->card->last4);
+        $this->assertTrue($user->hasPaymentMethod());
+        $this->assertFalse($user->hasDefaultPaymentMethod());
     }
 
     public function test_we_can_remove_payment_methods()
@@ -38,10 +40,12 @@ class PaymentMethodsTest extends IntegrationTestCase
         $paymentMethod = $user->addPaymentMethod('pm_card_visa');
 
         $this->assertCount(1, $user->paymentMethods());
+        $this->assertTrue($user->hasPaymentMethod());
 
         $user->removePaymentMethod($paymentMethod->asStripePaymentMethod());
 
         $this->assertCount(0, $user->paymentMethods());
+        $this->assertFalse($user->hasPaymentMethod());
     }
 
     public function test_we_can_remove_the_default_payment_method()
@@ -52,6 +56,8 @@ class PaymentMethodsTest extends IntegrationTestCase
         $paymentMethod = $user->updateDefaultPaymentMethod('pm_card_visa');
 
         $this->assertCount(1, $user->paymentMethods());
+        $this->assertTrue($user->hasPaymentMethod());
+        $this->assertTrue($user->hasDefaultPaymentMethod());
 
         $user->removePaymentMethod($paymentMethod->asStripePaymentMethod());
 
@@ -59,6 +65,8 @@ class PaymentMethodsTest extends IntegrationTestCase
         $this->assertNull($user->defaultPaymentMethod());
         $this->assertNull($user->card_brand);
         $this->assertNull($user->card_last_four);
+        $this->assertFalse($user->hasPaymentMethod());
+        $this->assertFalse($user->hasDefaultPaymentMethod());
     }
 
     public function test_we_can_set_a_default_payment_method()
@@ -71,6 +79,7 @@ class PaymentMethodsTest extends IntegrationTestCase
         $this->assertInstanceOf(PaymentMethod::class, $paymentMethod);
         $this->assertEquals('visa', $paymentMethod->card->brand);
         $this->assertEquals('4242', $paymentMethod->card->last4);
+        $this->assertTrue($user->hasDefaultPaymentMethod());
 
         $paymentMethod = $user->defaultPaymentMethod();
 

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -29,11 +29,11 @@ class CustomerTest extends TestCase
         $user = new User;
         $user->card_brand = 'visa';
 
-        $this->assertTrue($user->hasPaymentMethod());
+        $this->assertTrue($user->hasDefaultPaymentMethod());
 
         $user = new User;
 
-        $this->assertFalse($user->hasPaymentMethod());
+        $this->assertFalse($user->hasDefaultPaymentMethod());
     }
 
     public function test_default_payment_method_returns_null_when_the_user_is_not_a_customer_yet()


### PR DESCRIPTION
At the moment the `hasPaymentMethod` method will return false even if you just added one. Because customers can have payment methods without having a default one we'll need to differentiate and add a new dedicated `hasDefaultPaymentMethod` method. 

Sending this in to master for the obvious breaking change.

Closes https://github.com/laravel/cashier/issues/824