### PR TITLE
[10.x] PaymentMethod: Fix typo in exception message

### DIFF
--- a/src/PaymentMethod.php
+++ b/src/PaymentMethod.php
@@ -31,7 +31,7 @@ class PaymentMethod
     public function __construct($owner, StripePaymentMethod $paymentMethod)
     {
         if ($owner->stripe_id !== $paymentMethod->customer) {
-            throw new Exception("The invoice `{$paymentMethod->id}` does not belong to this customer `$owner->stripe_id`.");
+            throw new Exception("The payment method `{$paymentMethod->id}` does not belong to this customer `$owner->stripe_id`.");
         }
 
         $this->owner = $owner;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Error message should say `The payment method [...]`, not `The invoice [...]`.