### PR TITLE
[10.x] Fix findInvoiceOrFail behavior

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -4,6 +4,7 @@ namespace Laravel\Cashier;
 
 use Exception;
 use Illuminate\Support\Collection;
+use Laravel\Cashier\Exceptions\InvalidInvoice;
 use Laravel\Cashier\Exceptions\InvalidStripeCustomer;
 use Stripe\BankAccount as StripeBankAccount;
 use Stripe\Card as StripeCard;
@@ -294,14 +295,14 @@ trait Billable
      */
     public function findInvoiceOrFail($id)
     {
-        $invoice = $this->findInvoice($id);
+        try {
+            $invoice = $this->findInvoice($id);
+        } catch (InvalidInvoice $exception) {
+            throw new AccessDeniedHttpException;
+        }
 
         if (is_null($invoice)) {
             throw new NotFoundHttpException;
-        }
-
-        if ($invoice->customer !== $this->stripe_id) {
-            throw new AccessDeniedHttpException;
         }
 
         return $invoice;

--- a/src/Exceptions/InvalidInvoice.php
+++ b/src/Exceptions/InvalidInvoice.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravel\Cashier\Exceptions;
+
+use Exception;
+use Stripe\Invoice as StripeInvoice;
+
+class InvalidInvoice extends Exception
+{
+    /**
+     * Create a new InvalidInvoice instance.
+     *
+     * @param  \Stripe\Invoice  $invoice
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
+     * @return static
+     */
+    public static function invalidOwner(StripeInvoice $invoice, $owner)
+    {
+        return new static("The invoice `{$invoice->id}` does not belong to this customer `$owner->stripe_id`.");
+    }
+}

--- a/src/Exceptions/InvalidPaymentMethod.php
+++ b/src/Exceptions/InvalidPaymentMethod.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Laravel\Cashier\Exceptions;
+
+use Exception;
+use Stripe\PaymentMethod as StripePaymentMethod;
+
+class InvalidPaymentMethod extends Exception
+{
+    /**
+     * Create a new InvalidPaymentMethod instance.
+     *
+     * @param  \Stripe\PaymentMethod  $paymentMethod
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
+     * @return static
+     */
+    public static function invalidOwner(StripePaymentMethod $paymentMethod, $owner)
+    {
+        return new static("The payment method `{$paymentMethod->id}` does not belong to this customer `$owner->stripe_id`.");
+    }
+}

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -4,9 +4,9 @@ namespace Laravel\Cashier;
 
 use Carbon\Carbon;
 use Dompdf\Dompdf;
-use Exception;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\View;
+use Laravel\Cashier\Exceptions\InvalidInvoice;
 use Stripe\Invoice as StripeInvoice;
 use Stripe\InvoiceLineItem as StripeInvoiceLineItem;
 use Symfony\Component\HttpFoundation\Response;
@@ -40,11 +40,13 @@ class Invoice
      * @param  \Illuminate\Database\Eloquent\Model  $owner
      * @param  \Stripe\Invoice  $invoice
      * @return void
+     *
+     * @throws \Laravel\Cashier\Exceptions\InvalidInvoice
      */
     public function __construct($owner, StripeInvoice $invoice)
     {
         if ($owner->stripe_id !== $invoice->customer) {
-            throw new Exception("The invoice `{$invoice->id}` does not belong to this customer `$owner->stripe_id`.");
+            throw InvalidInvoice::invalidOwner($invoice, $owner);
         }
 
         $this->owner = $owner;

--- a/src/PaymentMethod.php
+++ b/src/PaymentMethod.php
@@ -2,7 +2,7 @@
 
 namespace Laravel\Cashier;
 
-use Exception;
+use Laravel\Cashier\Exceptions\InvalidPaymentMethod;
 use Stripe\PaymentMethod as StripePaymentMethod;
 
 class PaymentMethod
@@ -27,11 +27,13 @@ class PaymentMethod
      * @param  \Illuminate\Database\Eloquent\Model  $owner
      * @param  \Stripe\PaymentMethod  $paymentMethod
      * @return void
+     *
+     * @throws \Laravel\Cashier\Exceptions\InvalidPaymentMethod
      */
     public function __construct($owner, StripePaymentMethod $paymentMethod)
     {
         if ($owner->stripe_id !== $paymentMethod->customer) {
-            throw new Exception("The payment method `{$paymentMethod->id}` does not belong to this customer `$owner->stripe_id`.");
+            throw InvalidPaymentMethod::invalidOwner($paymentMethod, $owner);
         }
 
         $this->owner = $owner;


### PR DESCRIPTION
Because of the changes made to the constructor of the Invoice object recently, the subsequent findInvoiceOrFail method didn't throw the AccessDeniedHttpException anymore and instead threw the new Exception from the constructor. I've now fixed this method to properly throw the AccessDeniedHttpException again.

I've also changed the Exception classes to two dedicated Exception classes which people can type-hint against.

Fixes https://github.com/laravel/cashier/issues/851