### PR TITLE
get subscription by stripe id

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -2,11 +2,11 @@
 
 namespace Laravel\Cashier;
 
-use Money\Money;
-use Money\Currency;
-use NumberFormatter;
 use Money\Currencies\ISOCurrencies;
+use Money\Currency;
 use Money\Formatter\IntlMoneyFormatter;
+use Money\Money;
+use NumberFormatter;
 
 class Cashier
 {

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -2,11 +2,11 @@
 
 namespace Laravel\Cashier;
 
-use Money\Currencies\ISOCurrencies;
-use Money\Currency;
-use Money\Formatter\IntlMoneyFormatter;
 use Money\Money;
+use Money\Currency;
 use NumberFormatter;
+use Money\Currencies\ISOCurrencies;
+use Money\Formatter\IntlMoneyFormatter;
 
 class Cashier
 {
@@ -132,5 +132,10 @@ class Cashier
         static::$deactivatePastDue = false;
 
         return new static;
+    }
+
+    public static function findSubscriptionByStripeId($stripe_id)
+    {
+        return Subscription::where('stripe_id', $stripe_id)->first();
     }
 }

--- a/tests/Integration/SubscriptionsTest.php
+++ b/tests/Integration/SubscriptionsTest.php
@@ -615,4 +615,15 @@ class SubscriptionsTest extends IntegrationTestCase
 
         $this->assertEquals([self::$taxRateId], [$stripeSubscription->default_tax_rates[0]->id]);
     }
+
+    public function test_it_can_get_subscription_from_stripe_id()
+    {
+        $user = $this->createCustomer('test_subscription');
+
+        $subscription1 = $user->newSubscription('main', static::$planId)->create('pm_card_visa');
+
+        $subscription2 = Cashier::findSubscriptionByStripeId($subscription1->stripe_id);
+
+        $this->assertEquals($subscription1->stripe_id, $subscription2->stripe_id);
+    }
 }


### PR DESCRIPTION
PR'ing to master as per [Dries](https://discordapp.com/channels/297040613688475649/610866753395752968/676434076256960541).

I am building an addon on top of Cashier and part of it is sending emails on webhook events. In that listener I don't have the `Subscription` I only have the event payload.

Need a nice way to get the Subscription by Stripe id.