### PR TITLE
Move getUserByStripeId to Cashier

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -135,7 +135,7 @@ class Cashier
     }
 
     /**
-     * Get the user based on their Stripe id
+     * Get the user based on their Stripe id.
      *
      * @param string $stripeId
      * @return Billable

--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -133,4 +133,21 @@ class Cashier
 
         return new static;
     }
+
+    /**
+     * Get the user based on their Stripe id
+     *
+     * @param string $stripeId
+     * @return Billable
+     */
+    public static function getUserByStripeId($stripeId)
+    {
+        if ($stripeId === null) {
+            return;
+        }
+
+        $model = config('cashier.model');
+
+        return (new $model())->where('stripe_id', $stripeId)->first();
+    }
 }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -7,6 +7,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Events\WebhookHandled;
 use Laravel\Cashier\Events\WebhookReceived;
 use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
@@ -14,7 +15,6 @@ use Laravel\Cashier\Payment;
 use Laravel\Cashier\Subscription;
 use Stripe\PaymentIntent as StripePaymentIntent;
 use Symfony\Component\HttpFoundation\Response;
-use Laravel\Cashier\Cashier;
 
 class WebhookController extends Controller
 {


### PR DESCRIPTION
There was no convenient way to grab the relevant user from a webhook event (like `customer.subscription.created` without copying the code from `WebhookController`.

Move that method to the `Cashier` class and update the calls in `WebhookController`.

Now in my webhook controller I can do:
```php
$user = Cashier::getUserByStripeId($payload['data']['object']['id']);
```
