### PR TITLE
[11.x] Add subscription options + test

### DIFF
--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -204,12 +204,18 @@ class SubscriptionBuilder
      * @throws \Laravel\Cashier\Exceptions\PaymentActionRequired
      * @throws \Laravel\Cashier\Exceptions\PaymentFailure
      */
-    public function create($paymentMethod = null, array $options = [])
+    public function create($paymentMethod = null, array $options = [], $subscriptionOptions = [])
     {
         $customer = $this->getStripeCustomer($paymentMethod, $options);
 
+        $payload = array_merge(
+            ['customer' => $customer->id],
+            $this->buildPayload(),
+            $subscriptionOptions,
+        );
+
         $stripeSubscription = StripeSubscription::create(
-            ['customer' => $customer->id] + $this->buildPayload(),
+            $payload,
             $this->owner->stripeOptions()
         );
 

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -199,6 +199,7 @@ class SubscriptionBuilder
      *
      * @param  \Stripe\PaymentMethod|string|null  $paymentMethod
      * @param  array  $customerOptions
+     * @param  array  $subscriptionOptions
      * @return \Laravel\Cashier\Subscription
      *
      * @throws \Laravel\Cashier\Exceptions\PaymentActionRequired

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -198,20 +198,20 @@ class SubscriptionBuilder
      * Create a new Stripe subscription.
      *
      * @param  \Stripe\PaymentMethod|string|null  $paymentMethod
-     * @param  array  $options
+     * @param  array  $customerOptions
      * @return \Laravel\Cashier\Subscription
      *
      * @throws \Laravel\Cashier\Exceptions\PaymentActionRequired
      * @throws \Laravel\Cashier\Exceptions\PaymentFailure
      */
-    public function create($paymentMethod = null, array $options = [], $subscriptionOptions = [])
+    public function create($paymentMethod = null, array $customerOptions = [], array $subscriptionOptions = [])
     {
-        $customer = $this->getStripeCustomer($paymentMethod, $options);
+        $customer = $this->getStripeCustomer($paymentMethod, $customerOptions);
 
         $payload = array_merge(
             ['customer' => $customer->id],
             $this->buildPayload(),
-            $subscriptionOptions,
+            $subscriptionOptions
         );
 
         $stripeSubscription = StripeSubscription::create(

--- a/tests/Integration/SubscriptionsTest.php
+++ b/tests/Integration/SubscriptionsTest.php
@@ -615,4 +615,17 @@ class SubscriptionsTest extends IntegrationTestCase
 
         $this->assertEquals([self::$taxRateId], [$stripeSubscription->default_tax_rates[0]->id]);
     }
+
+    public function test_subscriptions_with_options_can_be_created()
+    {
+        $user = $this->createCustomer('subscriptions_with_options_can_be_created');
+
+        $backdate_timestamp = now()->subMonth()->getTimestamp();
+        $subscription = $user->newSubscription('main', static::$planId)->create('pm_card_visa', [], [
+            'backdate_start_date' => $backdate_timestamp,
+        ]);
+        $stripeSubscription = $subscription->asStripeSubscription();
+
+        $this->assertEquals($backdate_timestamp, $stripeSubscription->start_date);
+    }
 }

--- a/tests/Integration/SubscriptionsTest.php
+++ b/tests/Integration/SubscriptionsTest.php
@@ -620,12 +620,12 @@ class SubscriptionsTest extends IntegrationTestCase
     {
         $user = $this->createCustomer('subscriptions_with_options_can_be_created');
 
-        $backdate_timestamp = now()->subMonth()->getTimestamp();
+        $backdateStartDate = now()->subMonth()->getTimestamp();
         $subscription = $user->newSubscription('main', static::$planId)->create('pm_card_visa', [], [
-            'backdate_start_date' => $backdate_timestamp,
+            'backdate_start_date' => $backdateStartDate,
         ]);
         $stripeSubscription = $subscription->asStripeSubscription();
 
-        $this->assertEquals($backdate_timestamp, $stripeSubscription->start_date);
+        $this->assertEquals($backdateStartDate, $stripeSubscription->start_date);
     }
 }


### PR DESCRIPTION
This is a pull request to support additional subscriptions options, and resolves #787 

I was thinking about passing $subscriptionOptions and $customer into the buildPayload function, but ultimately decided to keep the PR simple. Let me know if you'd prefer the array merge to happen in the buildPayload function.