### PR TITLE
[10.x] Ability to get User by stripe id

### DIFF
--- a/src/Cashier.php
+++ b/src/Cashier.php
@@ -133,4 +133,21 @@ class Cashier
 
         return new static;
     }
+
+    /**
+     * Get the billable entity instance by Stripe ID.
+     *
+     * @param string $stripeId
+     * @return \Laravel\Cashier\Billable
+     */
+    public static function findBillable($stripeId)
+    {
+        if ($stripeId === null) {
+            return;
+        }
+
+        $model = config('cashier.model');
+
+        return (new $model)->where('stripe_id', $stripeId)->first();
+    }
 }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -208,7 +208,7 @@ class WebhookController extends Controller
      */
     protected function getUserByStripeId($stripeId)
     {
-        return Cashier::findBillable($stripeId)
+        return Cashier::findBillable($stripeId);
     }
 
     /**

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -7,6 +7,7 @@ use Illuminate\Notifications\Notifiable;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Events\WebhookHandled;
 use Laravel\Cashier\Events\WebhookReceived;
 use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
@@ -207,13 +208,7 @@ class WebhookController extends Controller
      */
     protected function getUserByStripeId($stripeId)
     {
-        if ($stripeId === null) {
-            return;
-        }
-
-        $model = config('cashier.model');
-
-        return (new $model)->where('stripe_id', $stripeId)->first();
+        return Cashier::findBillable($stripeId)
     }
 
     /**


### PR DESCRIPTION
There was no convenient way to grab the relevant user from a webhook event (like `customer.subscription.created` without copying the code from WebhookController.

Move that method to the Cashier class and update the calls in WebhookController.

Now in my webhook controller I can do:

```php
$user = Cashier::findBillable($payload['data']['object']['id']);
```

Updated previous PR as per Dries' comments in https://github.com/laravel/cashier/pull/867/.
