### PR TITLE
[10.x] Mark markAsCancelled as internal

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -552,6 +552,7 @@ class Subscription extends Model
      * Mark the subscription as cancelled.
      *
      * @return void
+     * @internal
      */
     public function markAsCancelled()
     {


### PR DESCRIPTION
This method is only used because of the webhook controller events and shouldn't be used outside the library. It's not documented for this reason.

See https://github.com/laravel/cashier/issues/864