### PR TITLE
[10.x] Prevent createAsStripeCustomer when stripe_id is set

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -727,6 +727,10 @@ trait Billable
      */
     public function createAsStripeCustomer(array $options = [])
     {
+        if ($this->stripe_id) {
+            throw InvalidStripeCustomer::exists($this);
+        }
+
         $options = array_key_exists('email', $options)
                 ? $options
                 : array_merge($options, ['email' => $this->email]);

--- a/src/Exceptions/InvalidPaymentMethod.php
+++ b/src/Exceptions/InvalidPaymentMethod.php
@@ -16,6 +16,8 @@ class InvalidPaymentMethod extends Exception
      */
     public static function invalidOwner(StripePaymentMethod $paymentMethod, $owner)
     {
-        return new static("The payment method `{$paymentMethod->id}` does not belong to this customer `$owner->stripe_id`.");
+        return new static(
+            "The payment method `{$paymentMethod->id}` does not belong to this customer `$owner->stripe_id`."
+        );
     }
 }

--- a/src/Exceptions/InvalidStripeCustomer.php
+++ b/src/Exceptions/InvalidStripeCustomer.php
@@ -7,13 +7,24 @@ use Exception;
 class InvalidStripeCustomer extends Exception
 {
     /**
-     * Create a new CustomerFailure instance.
+     * Create a new InvalidStripeCustomer instance.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $owner
-     * @return self
+     * @return static
      */
     public static function nonCustomer($owner)
     {
         return new static(class_basename($owner).' is not a Stripe customer. See the createAsStripeCustomer method.');
+    }
+
+    /**
+     * Create a new InvalidStripeCustomer instance.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $owner
+     * @return static
+     */
+    public static function exists($owner)
+    {
+        return new static(class_basename($owner)." is already a Stripe customer with ID {$owner->stripe_id}.");
     }
 }

--- a/src/Exceptions/PaymentActionRequired.php
+++ b/src/Exceptions/PaymentActionRequired.php
@@ -10,11 +10,11 @@ class PaymentActionRequired extends IncompletePayment
      * Create a new PaymentActionRequired instance.
      *
      * @param  \Laravel\Cashier\Payment  $payment
-     * @return self
+     * @return static
      */
     public static function incomplete(Payment $payment)
     {
-        return new self(
+        return new static(
             $payment,
             'The payment attempt failed because additional action is required before it can be completed.'
         );

--- a/src/Exceptions/PaymentFailure.php
+++ b/src/Exceptions/PaymentFailure.php
@@ -10,11 +10,11 @@ class PaymentFailure extends IncompletePayment
      * Create a new PaymentFailure instance.
      *
      * @param  \Laravel\Cashier\Payment  $payment
-     * @return self
+     * @return static
      */
     public static function invalidPaymentMethod(Payment $payment)
     {
-        return new self(
+        return new static(
             $payment,
             'The payment attempt failed because of an invalid payment method.'
         );

--- a/src/Exceptions/SubscriptionUpdateFailure.php
+++ b/src/Exceptions/SubscriptionUpdateFailure.php
@@ -12,10 +12,12 @@ class SubscriptionUpdateFailure extends Exception
      *
      * @param  \Laravel\Cashier\Subscription  $subscription
      * @param  string  $plan
-     * @return self
+     * @return static
      */
     public static function incompleteSubscription(Subscription $subscription)
     {
-        return new static("The subscription \"{$subscription->stripe_id}\" cannot be updated because its payment is incomplete.");
+        return new static(
+            "The subscription \"{$subscription->stripe_id}\" cannot be updated because its payment is incomplete."
+        );
     }
 }

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -51,4 +51,14 @@ class CustomerTest extends TestCase
 
         $user->asStripeCustomer();
     }
+
+    public function test_stripe_customer_cannot_be_created_when_stripe_id_is_already_set()
+    {
+        $user = new User();
+        $user->stripe_id = 'foo';
+
+        $this->expectException(InvalidStripeCustomer::class);
+
+        $user->createAsStripeCustomer();
+    }
 }


### PR DESCRIPTION
This will prevent usage of the `createAsStripeCustomer` when a stripe id is already set. Usage like this can be dangerous because a new stripe customer will be created and the link to the previous customer will be lost.

Fixes https://github.com/laravel/cashier/issues/862