### PR TITLE
Add @throws declaration to methods on Billable which can throw Payment exceptions

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -29,6 +29,9 @@ trait Billable
      * @param  string  $paymentMethod
      * @param  array  $options
      * @return \Laravel\Cashier\Payment
+     *
+     * @throws \Laravel\Cashier\Exceptions\PaymentActionRequired
+     * @throws \Laravel\Cashier\Exceptions\PaymentFailure
      */
     public function charge($amount, $paymentMethod, array $options = [])
     {
@@ -99,6 +102,9 @@ trait Billable
      * @param  array  $tabOptions
      * @param  array  $invoiceOptions
      * @return \Laravel\Cashier\Invoice|bool
+     *
+     * @throws \Laravel\Cashier\Exceptions\PaymentActionRequired
+     * @throws \Laravel\Cashier\Exceptions\PaymentFailure
      */
     public function invoiceFor($description, $amount, array $tabOptions = [], array $invoiceOptions = [])
     {
@@ -220,6 +226,9 @@ trait Billable
      *
      * @param  array  $options
      * @return \Laravel\Cashier\Invoice|bool
+     *
+     * @throws \Laravel\Cashier\Exceptions\PaymentActionRequired
+     * @throws \Laravel\Cashier\Exceptions\PaymentFailure
      */
     public function invoice(array $options = [])
     {


### PR DESCRIPTION
In the documentation https://laravel.com/docs/6.x/billing#payments-requiring-additional-confirmation it's stated the the methods `charge` `invoice` and `invoiceFor` on a user can throw `IncompletePayment` exceptions but the methods documention wasn't marked as such.

This PR just adds those `@throws` tags to the methods.
