### PR TITLE
[11.x] Fix a bug with tax rates

### DIFF
--- a/src/InvoiceLineItem.php
+++ b/src/InvoiceLineItem.php
@@ -132,6 +132,10 @@ class InvoiceLineItem
      */
     public function hasTaxRates()
     {
+        if ($this->invoice->isNotTaxExempt()) {
+            return ! empty($this->item->tax_amounts);
+        }
+
         return ! empty($this->item->tax_rates);
     }
 


### PR DESCRIPTION
This fixes a bug where tax rates weren't showing for non-tax except customers and only inclusive tax was applied.

Fixes https://github.com/laravel/cashier/issues/854