### PR TITLE
[11.x] Use proper invoice number

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -101,7 +101,7 @@
                 <!-- Invoice Info -->
                 <p>
                     <strong>Product:</strong> {{ $product }}<br>
-                    <strong>Invoice Number:</strong> {{ $id ?? $invoice->id }}<br>
+                    <strong>Invoice Number:</strong> {{ $id ?? $invoice->number }}<br>
                 </p>
 
                 <!-- Extra / VAT Information -->


### PR DESCRIPTION
This changes the invoice number on receipts to the actual invoice number in Stripe. The current id is Stripe internal identifier for doing API requests while the invoice number is the one set in Stripe to identify the invoice as an incremental number.

Sending this in to master because of the change in behavior.

Closes https://github.com/laravel/cashier/issues/845