### PR TITLE
[10.x] Update payment page with new JS method

### DIFF
--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -125,9 +125,10 @@
                     this.successMessage = '';
                     this.errorMessage = '';
 
-                    stripe.handleCardPayment(
-                        '{{ $payment->clientSecret() }}', this.cardElement, {
-                            payment_method_data: {
+                    stripe.confirmCardPayment(
+                        '{{ $payment->clientSecret() }}', {
+                            payment_method: {
+                                card: this.cardElement,
                                 billing_details: { name: this.name }
                             }
                         }


### PR DESCRIPTION
This replaces [the deprecated method](https://stripe.com/docs/js/deprecated/handle_card_payment_element) with [the new one](https://stripe.com/docs/js/payment_intents/confirm_card_payment#stripe_confirm_card_payment-data-payment_method).

Closes https://github.com/laravel/cashier/issues/844