### PR TITLE
[11.x] Loosen exception throwing

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -44,7 +44,7 @@ trait Billable
         $options['amount'] = $amount;
         $options['payment_method'] = $paymentMethod;
 
-        if ($this->stripe_id) {
+        if ($this->hasStripeId()) {
             $options['customer'] = $this->stripe_id;
         }
 
@@ -264,7 +264,9 @@ trait Billable
      */
     public function upcomingInvoice()
     {
-        $this->assertCustomerExists();
+        if (! $this->hasStripeId()) {
+            return;
+        }
 
         try {
             $stripeInvoice = StripeInvoice::upcoming(['customer' => $this->stripe_id], $this->stripeOptions());
@@ -338,7 +340,9 @@ trait Billable
      */
     public function invoices($includePending = false, $parameters = [])
     {
-        $this->assertCustomerExists();
+        if (! $this->hasStripeId()) {
+            return collect();
+        }
 
         $invoices = [];
 
@@ -415,7 +419,9 @@ trait Billable
      */
     public function paymentMethods($parameters = [])
     {
-        $this->assertCustomerExists();
+        if (! $this->hasStripeId()) {
+            return collect();
+        }
 
         $parameters = array_merge(['limit' => 24], $parameters);
 
@@ -733,7 +739,7 @@ trait Billable
      */
     protected function assertCustomerExists()
     {
-        if (! $this->stripe_id) {
+        if (! $this->hasStripeId()) {
             throw InvalidStripeCustomer::nonCustomer($this);
         }
     }
@@ -746,7 +752,7 @@ trait Billable
      */
     public function createAsStripeCustomer(array $options = [])
     {
-        if ($this->stripe_id) {
+        if ($this->hasStripeId()) {
             throw InvalidStripeCustomer::exists($this);
         }
 
@@ -789,7 +795,7 @@ trait Billable
      */
     public function createOrGetStripeCustomer(array $options = [])
     {
-        if ($this->stripe_id) {
+        if ($this->hasStripeId()) {
             return $this->asStripeCustomer();
         }
 


### PR DESCRIPTION
The idea behind these changes is that these methods should still be able to be used even if the Billable model isn't a Stripe customer yet. By default we can assume that when a Billable model isn't a Stripe customer yet that no invoices, payment methods or upcoming invoice exists yet.