### PR TITLE
[10.x] Implement extending trials

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -3,8 +3,10 @@
 namespace Laravel\Cashier;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
 use Laravel\Cashier\Exceptions\IncompletePayment;
 use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use LogicException;
@@ -421,6 +423,33 @@ class Subscription extends Model
     public function skipTrial()
     {
         $this->trial_ends_at = null;
+
+        return $this;
+    }
+
+    /**
+     * Extend an existing subscription's trial period.
+     *
+     * @param  \Carbon\CarbonInterface  $date
+     * @return $this
+     */
+    public function extendTrial(CarbonInterface $date)
+    {
+        if (! $date->isFuture()) {
+            throw new InvalidArgumentException("Extending a subscription's trial requires a date in the future.");
+        }
+
+        $subscription = $this->asStripeSubscription();
+
+        $subscription->prorate = $this->prorate;
+
+        $subscription->trial_end = $date->getTimestamp();
+
+        $subscription->save();
+
+        $this->trial_ends_at = $date;
+
+        $this->save();
 
         return $this;
     }

--- a/tests/Integration/SubscriptionsTest.php
+++ b/tests/Integration/SubscriptionsTest.php
@@ -463,6 +463,20 @@ class SubscriptionsTest extends IntegrationTestCase
         $this->assertEquals(Carbon::tomorrow()->hour(3)->minute(15), $subscription->trial_ends_at);
     }
 
+    public function test_trials_can_be_extended()
+    {
+        $user = $this->createCustomer('trials_can_be_extended');
+
+        $subscription = $user->newSubscription('main', static::$planId)->create('pm_card_visa');
+
+        $this->assertNull($subscription->trial_ends_at);
+
+        $subscription->extendTrial($trialEndsAt = now()->addDays()->floor());
+
+        $this->assertTrue($trialEndsAt->equalTo($subscription->trial_ends_at));
+        $this->assertEquals($subscription->asStripeSubscription()->trial_end, $trialEndsAt->getTimestamp());
+    }
+
     public function test_applying_coupons_to_existing_customers()
     {
         $user = $this->createCustomer('applying_coupons_to_existing_customers');

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Tests\Unit;
 
+use InvalidArgumentException;
 use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use Laravel\Cashier\Subscription;
 use PHPUnit\Framework\TestCase;
@@ -93,5 +94,12 @@ class SubscriptionTest extends TestCase
         $this->expectException(SubscriptionUpdateFailure::class);
 
         $subscription->updateQuantity(5);
+    }
+
+    public function test_extending_a_trial_requires_a_date_in_the_future()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Subscription)->extendTrial(now()->subDay());
     }
 }


### PR DESCRIPTION
This will allow for extending trial periods on existing subscriptions to allow customers some additional time after they've already subscribed.

Closes https://github.com/laravel/cashier/issues/550
