### PR TITLE
[10.x] Do not allow changing prorating when extending trials

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -441,8 +441,6 @@ class Subscription extends Model
 
         $subscription = $this->asStripeSubscription();
 
-        $subscription->prorate = $this->prorate;
-
         $subscription->trial_end = $date->getTimestamp();
 
         $subscription->save();


### PR DESCRIPTION
Follow up for #884. I realized that allowing to prevent prorating when extending trials kind of defeats the purpose of the feature.