### PR TITLE
[10.x] Re-enable proration

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -397,6 +397,18 @@ class Subscription extends Model
     }
 
     /**
+     * Indicate that the plan change should be prorated.
+     *
+     * @return $this
+     */
+    public function prorate()
+    {
+        $this->prorate = true;
+
+        return $this;
+    }
+
+    /**
      * Change the billing cycle anchor on a plan change.
      *
      * @param  \DateTimeInterface|int|string  $date

--- a/tests/Integration/SubscriptionsTest.php
+++ b/tests/Integration/SubscriptionsTest.php
@@ -463,6 +463,30 @@ class SubscriptionsTest extends IntegrationTestCase
         $this->assertEquals(Carbon::tomorrow()->hour(3)->minute(15), $subscription->trial_ends_at);
     }
 
+    public function test_subscription_changes_can_be_prorated()
+    {
+        $user = $this->createCustomer('subscription_changes_can_be_prorated');
+
+        $subscription = $user->newSubscription('main', static::$premiumPlanId)->create('pm_card_visa');
+
+        $this->assertEquals(2000, ($invoice = $user->invoices()->first())->rawTotal());
+
+        $subscription->noProrate()->swapAndInvoice(static::$planId);
+
+        // Assert that no new invoice was created because of no prorating.
+        $this->assertEquals($invoice->id, $user->invoices()->first()->id);
+
+        $subscription->swapAndInvoice(static::$premiumPlanId);
+
+        // Assert that no new invoice was created because of no prorating.
+        $this->assertEquals($invoice->id, $user->invoices()->first()->id);
+
+        $subscription->prorate()->swapAndInvoice(static::$planId);
+
+        // Get back from unused time on premium plan.
+        $this->assertEquals(-1000, $user->invoices()->first()->rawTotal());
+    }
+
     public function test_trials_can_be_extended()
     {
         $user = $this->createCustomer('trials_can_be_extended');


### PR DESCRIPTION
Re-send of https://github.com/laravel/cashier/pull/717

This will allow to re-enable prorating when doing multiple swaps in one request. Also adds tests for proration.

Closes https://github.com/laravel/cashier/issues/647