### PR TITLE
[10.x] Make email optional

### DIFF
--- a/resources/views/receipt.blade.php
+++ b/resources/views/receipt.blade.php
@@ -67,7 +67,7 @@
             <!-- Organization Name / Date -->
             <td>
                 <br><br>
-                <strong>To:</strong> {{ $owner->email ?: $owner->name }}
+                <strong>To:</strong> {{ $owner->stripeEmail() ?: $owner->name }}
                 <br>
                 <strong>Date:</strong> {{ $invoice->date()->toFormattedDateString() }}
             </td>

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -729,6 +729,16 @@ trait Billable
     }
 
     /**
+     * Get the email address used to create the customer in Stripe.
+     *
+     * @return string|null
+     */
+    public function stripeEmail()
+    {
+        return $this->email;
+    }
+
+    /**
      * Create a Stripe customer for the given model.
      *
      * @param  array  $options
@@ -740,9 +750,9 @@ trait Billable
             throw InvalidStripeCustomer::exists($this);
         }
 
-        $options = array_key_exists('email', $options)
-                ? $options
-                : array_merge($options, ['email' => $this->email]);
+        if (! array_key_exists('email', $options) && $email = $this->stripeEmail()) {
+            $options['email'] = $email;
+        }
 
         // Here we will create the customer instance on Stripe and store the ID of the
         // user from Stripe. This ID will correspond with the Stripe user instances

--- a/src/Billable.php
+++ b/src/Billable.php
@@ -729,16 +729,6 @@ trait Billable
     }
 
     /**
-     * Get the email address used to create the customer in Stripe.
-     *
-     * @return string|null
-     */
-    public function stripeEmail()
-    {
-        return $this->email;
-    }
-
-    /**
      * Create a Stripe customer for the given model.
      *
      * @param  array  $options
@@ -806,6 +796,16 @@ trait Billable
         $this->assertCustomerExists();
 
         return StripeCustomer::retrieve($this->stripe_id, $this->stripeOptions());
+    }
+
+    /**
+     * Get the email address used to create the customer in Stripe.
+     *
+     * @return string|null
+     */
+    public function stripeEmail()
+    {
+        return $this->email;
     }
 
     /**


### PR DESCRIPTION
Email address isn't required when creating a customer in Stripe. It can be added at a later time or not at all. Email capabilities from Stripe out aren't available in this case but that's not always needed.

This also allows to customize which attribute on the model should be used for the email address.

Closes https://github.com/laravel/cashier/issues/485