### PR TITLE
[11.x] Allow for custom filename with downloadInvoice method

### DIFF
--- a/src/Billable.php
+++ b/src/Billable.php
@@ -328,11 +328,14 @@ trait Billable
      *
      * @param  string  $id
      * @param  array  $data
+     * @param  string  $filename
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function downloadInvoice($id, array $data)
+    public function downloadInvoice($id, array $data, $filename = null)
     {
-        return $this->findInvoiceOrFail($id)->download($data);
+        $invoice = $this->findInvoiceOrFail($id);
+
+        return $filename ? $invoice->downloadAs($filename, $data) : $invoice->download($data);
     }
 
     /**


### PR DESCRIPTION
Allows to easily set a custom filename when downloading an invoice directly from a Billable model.