### PR TITLE
[10.x] Redirect with status

### DIFF
--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -149,6 +149,7 @@
                         }
                     });
                 },
+
                 goBack: function () {
                     var self = this;
                     var button = this.$refs.goBackButton;

--- a/resources/views/payment.blade.php
+++ b/resources/views/payment.blade.php
@@ -80,10 +80,10 @@
                     </div>
                 @endif
 
-                <a href="{{ $redirect ?? url('/') }}"
+                <button @click="goBack" ref="goBackButton" data-redirect="{{ $redirect ?? url('/') }}"
                    class="inline-block w-full px-4 py-3 bg-gray-200 hover:bg-gray-300 text-center text-gray-700 rounded-lg">
                     {{ __('Go back') }}
-                </a>
+                </button>
             </div>
 
             <p class="text-center text-gray-500 text-sm">
@@ -148,6 +148,18 @@
                             self.successMessage = '{{ __('The payment was successful.') }}';
                         }
                     });
+                },
+                goBack: function () {
+                    var self = this;
+                    var button = this.$refs.goBackButton;
+                    var redirect = new URL(button.dataset.redirect);
+
+                    if (self.successMessage || self.errorMessage) {
+                        redirect.searchParams.append('message', self.successMessage ? self.successMessage : self.errorMessage);
+                        redirect.searchParams.append('success', !! self.successMessage);
+                    }
+
+                    window.location.href = redirect;
                 },
             },
         })


### PR DESCRIPTION
At the moment when you go back from a payment page after a successful single charge there's no way of knowing if the payment was successful. These changes allow the go back button to send a status message and succes query parameters upon succes or failure.

Closes https://github.com/laravel/cashier/issues/848