### PR TITLE
[9.x] add X-Vapor-Base64-Encode header

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -275,6 +275,7 @@ class Invoice
             'Content-Disposition' => 'attachment; filename="'.$filename.'"',
             'Content-Transfer-Encoding' => 'binary',
             'Content-Type' => 'application/pdf',
+            'X-Vapor-Base64-Encode' => 'True',
         ]);
     }
 


### PR DESCRIPTION
This adds the `X-Vapor-Base64-Encode` header to the 9.x release. We currently use Cashier, and are unable to upgrade to 10.x due to several infrastructure blockers (they're actively being worked on). This is to add support out of the box so we don't have to extend Cashier.

I'm sure this will help others who are in a similar situation, but can't immediately upgrade to 10.x.