### PR TITLE
[11.x] Multiplan subscriptions

### DIFF
--- a/database/migrations/2019_05_03_000002_create_subscriptions_table.php
+++ b/database/migrations/2019_05_03_000002_create_subscriptions_table.php
@@ -19,8 +19,8 @@ class CreateSubscriptionsTable extends Migration
             $table->string('name');
             $table->string('stripe_id');
             $table->string('stripe_status');
-            $table->string('stripe_plan');
-            $table->integer('quantity');
+            $table->string('stripe_plan')->nullable();
+            $table->integer('quantity')->nullable();
             $table->timestamp('trial_ends_at')->nullable();
             $table->timestamp('ends_at')->nullable();
             $table->timestamps();

--- a/database/migrations/2019_05_03_000003_create_subscription_items_table.php
+++ b/database/migrations/2019_05_03_000003_create_subscription_items_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSubscriptionItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('subscription_items', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('subscription_id');
+            $table->string('stripe_id');
+            $table->string('stripe_plan');
+            $table->integer('quantity');
+            $table->timestamps();
+
+            $table->unique(['subscription_id', 'stripe_plan']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('subscription_items');
+    }
+}

--- a/database/migrations/2019_05_03_000003_create_subscription_items_table.php
+++ b/database/migrations/2019_05_03_000003_create_subscription_items_table.php
@@ -16,7 +16,7 @@ class CreateSubscriptionItemsTable extends Migration
         Schema::create('subscription_items', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('subscription_id');
-            $table->string('stripe_id');
+            $table->string('stripe_id')->index();
             $table->string('stripe_plan');
             $table->integer('quantity');
             $table->timestamps();

--- a/src/Exceptions/SubscriptionUpdateFailure.php
+++ b/src/Exceptions/SubscriptionUpdateFailure.php
@@ -13,10 +13,50 @@ class SubscriptionUpdateFailure extends Exception
      * @param  \Laravel\Cashier\Subscription  $subscription
      * @return static
      */
+    public static function swapOnMultiplan(Subscription $subscription)
+    {
+        return new static(
+            "The subscription \"{$subscription->stripe_id}\" cannot be swapped because it has multiple plans."
+        );
+    }
+
+    /**
+     * Create a new SubscriptionUpdateFailure instance.
+     *
+     * @param  \Laravel\Cashier\Subscription  $subscription
+     * @return static
+     */
     public static function incompleteSubscription(Subscription $subscription)
     {
         return new static(
             "The subscription \"{$subscription->stripe_id}\" cannot be updated because its payment is incomplete."
+        );
+    }
+
+    /**
+     * Create a new SubscriptionUpdateFailure instance.
+     *
+     * @param  \Laravel\Cashier\Subscription  $subscription
+     * @param  string  $plan
+     * @return static
+     */
+    public static function duplicatePlan(Subscription $subscription, $plan)
+    {
+        return new static(
+            "The plan \"$plan\" on subscription \"{$subscription->stripe_id}\" already exists."
+        );
+    }
+
+    /**
+     * Create a new SubscriptionUpdateFailure instance.
+     *
+     * @param  \Laravel\Cashier\Subscription  $subscription
+     * @return static
+     */
+    public static function cannotDeleteLastPlan(Subscription $subscription)
+    {
+        return new static(
+            "The plan on subscription \"{$subscription->stripe_id}\" cannot be removed because it is the last one."
         );
     }
 }

--- a/src/Exceptions/SubscriptionUpdateFailure.php
+++ b/src/Exceptions/SubscriptionUpdateFailure.php
@@ -43,7 +43,7 @@ class SubscriptionUpdateFailure extends Exception
     public static function duplicatePlan(Subscription $subscription, $plan)
     {
         return new static(
-            "The plan \"$plan\" on subscription \"{$subscription->stripe_id}\" already exists."
+            "The plan \"$plan\" is already attached to subscription \"{$subscription->stripe_id}\"."
         );
     }
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -839,6 +839,11 @@ class Subscription extends Model
 
         $subscription->cancel_at_period_end = false;
 
+        // To resume the subscription we need to set the plan parameter on the Stripe
+        // subscription object. This will force Stripe to resume this subscription
+        // where we left off. Then, we'll set the proper trial ending timestamp.
+        $subscription->plan = $this->stripe_plan;
+
         if ($this->onTrial()) {
             $subscription->trial_end = $this->trial_ends_at->getTimestamp();
         } else {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -600,9 +600,7 @@ class Subscription extends Model
         $subscription = $this->asStripeSubscription();
 
         $subscription->plan = $plan;
-
         $subscription->proration_behavior = $this->prorateBehavior();
-
         $subscription->cancel_at_period_end = false;
 
         if (! is_null($this->billingCycleAnchor)) {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -29,6 +29,15 @@ class Subscription extends Model
     protected $with = ['items'];
 
     /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'quantity' => 'integer',
+    ];
+
+    /**
      * The attributes that should be mutated to dates.
      *
      * @var array
@@ -36,15 +45,6 @@ class Subscription extends Model
     protected $dates = [
         'trial_ends_at', 'ends_at',
         'created_at', 'updated_at',
-    ];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'quantity' => 'integer',
     ];
 
     /**
@@ -953,7 +953,7 @@ class Subscription extends Model
     {
         if (is_null($plan) && $this->hasMultiplePlans()) {
             throw new InvalidArgumentException(
-                'This method needs a plan argument because the subscription has multiple plans.'
+                'This method requires a plan argument since the subscription has multiple plans.'
             );
         }
     }

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -4,6 +4,8 @@ namespace Laravel\Cashier;
 
 use Carbon\Carbon;
 use DateTimeInterface;
+use Illuminate\Support\Arr;
+use InvalidArgumentException;
 use Stripe\Subscription as StripeSubscription;
 
 class SubscriptionBuilder
@@ -25,16 +27,9 @@ class SubscriptionBuilder
     /**
      * The name of the plan being subscribed to.
      *
-     * @var string
+     * @var array
      */
-    protected $plan;
-
-    /**
-     * The quantity of the subscription.
-     *
-     * @var int
-     */
-    protected $quantity = 1;
+    protected $items;
 
     /**
      * The date and time the trial will expire.
@@ -76,27 +71,55 @@ class SubscriptionBuilder
      *
      * @param  mixed  $owner
      * @param  string  $name
-     * @param  string  $plan
+     * @param  string|array  $plans
      * @return void
      */
-    public function __construct($owner, $name, $plan)
+    public function __construct($owner, $name, $plans = null)
     {
         $this->name = $name;
-        $this->plan = $plan;
         $this->owner = $owner;
+
+        foreach ((array) $plans as $plan) {
+            $this->plan($plan);
+        }
     }
 
     /**
-     * Specify the quantity of the subscription.
+     * Set a plan on the subscription builder.
      *
+     * @param  string  $plan
      * @param  int  $quantity
      * @return $this
      */
-    public function quantity($quantity)
+    public function plan($plan, $quantity = 1)
     {
-        $this->quantity = $quantity;
+        $this->items[$plan] = [
+            'plan' => $plan,
+            'quantity' => $quantity,
+            'tax_rates' => $this->getPlanTaxRatesForPayload($plan),
+        ];
 
         return $this;
+    }
+
+    /**
+     * Specify the quantity of a subscription item.
+     *
+     * @param  int  $quantity
+     * @param  string|null  $plan
+     * @return $this
+     */
+    public function quantity($quantity, $plan = null)
+    {
+        if (is_null($plan)) {
+            if (count($this->items) > 1) {
+                throw new InvalidArgumentException('Plan is required when creating multi plan subscriptions.');
+            }
+
+            $plan = Arr::first($this->items)['plan'];
+        }
+
+        return $this->plan($plan, $quantity);
     }
 
     /**
@@ -232,11 +255,20 @@ class SubscriptionBuilder
             'name' => $this->name,
             'stripe_id' => $stripeSubscription->id,
             'stripe_status' => $stripeSubscription->status,
-            'stripe_plan' => $this->plan,
-            'quantity' => $this->quantity,
+            'stripe_plan' => $stripeSubscription->plan ? $stripeSubscription->plan->id : null,
+            'quantity' => $stripeSubscription->quantity,
             'trial_ends_at' => $trialEndsAt,
             'ends_at' => null,
         ]);
+
+        /** @var \Stripe\SubscriptionItem $item */
+        foreach ($stripeSubscription->items as $item) {
+            $subscription->items()->create([
+                'stripe_id' => $item->id,
+                'stripe_plan' => $item->plan->id,
+                'quantity' => $item->quantity,
+            ]);
+        }
 
         if ($subscription->incomplete()) {
             (new Payment(
@@ -277,8 +309,7 @@ class SubscriptionBuilder
             'coupon' => $this->coupon,
             'expand' => ['latest_invoice.payment_intent'],
             'metadata' => $this->metadata,
-            'plan' => $this->plan,
-            'quantity' => $this->quantity,
+            'items' => collect($this->items)->values()->all(),
             'default_tax_rates' => $this->getTaxRatesForPayload(),
             'trial_end' => $this->getTrialEndForPayload(),
             'off_session' => true,
@@ -310,6 +341,19 @@ class SubscriptionBuilder
     {
         if ($taxRates = $this->owner->taxRates()) {
             return $taxRates;
+        }
+    }
+
+    /**
+     * Get the plan tax rates for the Stripe payload.
+     *
+     * @param  string  $plan
+     * @return array|null
+     */
+    protected function getPlanTaxRatesForPayload($plan)
+    {
+        if ($taxRates = $this->owner->planTaxRates()) {
+            return $taxRates[$plan] ?? null;
         }
     }
 }

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -113,7 +113,7 @@ class SubscriptionBuilder
     {
         if (is_null($plan)) {
             if (count($this->items) > 1) {
-                throw new InvalidArgumentException('Plan is required when creating multi plan subscriptions.');
+                throw new InvalidArgumentException('Plan is required when creating multi-plan subscriptions.');
             }
 
             $plan = Arr::first($this->items)['plan'];

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Laravel\Cashier;
+
+use Illuminate\Database\Eloquent\Model;
+use Stripe\SubscriptionItem as StripeSubscriptionItem;
+
+class SubscriptionItem extends Model
+{
+    /**
+     * The attributes that are not mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'quantity' => 'integer',
+    ];
+
+    /**
+     * Get the subscription where the item belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function subscription()
+    {
+        return $this->belongsTo(Subscription::class);
+    }
+
+    /**
+     * Get the subscription as a Stripe subscription item object.
+     *
+     * @return \Stripe\SubscriptionItem
+     */
+    public function asStripeSubscriptionItem()
+    {
+        return StripeSubscriptionItem::retrieve(
+            $this->stripe_id,
+            $this->subscription->owner->stripeOptions()
+        );
+    }
+}

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -24,7 +24,7 @@ class SubscriptionItem extends Model
     ];
 
     /**
-     * Get the subscription where the item belongs to.
+     * Get the subscription that the item belongs to.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */

--- a/tests/Feature/FeatureTestCase.php
+++ b/tests/Feature/FeatureTestCase.php
@@ -46,12 +46,12 @@ abstract class FeatureTestCase extends TestCase
         }
     }
 
-    protected function createCustomer($description = 'taylor'): User
+    protected function createCustomer($description = 'taylor', $options = []): User
     {
-        return User::create([
+        return User::create(array_merge([
             'email' => "{$description}@cashier-test.com",
             'name' => 'Taylor Otwell',
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
-        ]);
+        ], $options));
     }
 }

--- a/tests/Feature/MultiplanSubscriptionsTest.php
+++ b/tests/Feature/MultiplanSubscriptionsTest.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Laravel\Cashier\Tests\Feature;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
+use Laravel\Cashier\Tests\Fixtures\User;
+use Stripe\Plan;
+use Stripe\Product;
+use Stripe\TaxRate;
+
+class MultiplanSubscriptionsTest extends FeatureTestCase
+{
+    /**
+     * @var string
+     */
+    protected static $productId;
+
+    /**
+     * @var string
+     */
+    protected static $planId;
+
+    /**
+     * @var string
+     */
+    protected static $otherPlanId;
+
+    /**
+     * @var string
+     */
+    protected static $premiumPlanId;
+
+    /**
+     * @var string
+     */
+    protected static $taxRateId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        static::$productId = static::$stripePrefix.'product-1'.Str::random(10);
+        static::$planId = static::$stripePrefix.'monthly-10-'.Str::random(10);
+        static::$otherPlanId = static::$stripePrefix.'monthly-10-'.Str::random(10);
+        static::$premiumPlanId = static::$stripePrefix.'monthly-20-premium-'.Str::random(10);
+
+        Product::create([
+            'id' => static::$productId,
+            'name' => 'Laravel Cashier Test Product',
+            'type' => 'service',
+        ]);
+
+        Plan::create([
+            'id' => static::$planId,
+            'nickname' => 'Monthly $10',
+            'currency' => 'USD',
+            'interval' => 'month',
+            'billing_scheme' => 'per_unit',
+            'amount' => 1000,
+            'product' => static::$productId,
+        ]);
+
+        Plan::create([
+            'id' => static::$otherPlanId,
+            'nickname' => 'Monthly $10 Other',
+            'currency' => 'USD',
+            'interval' => 'month',
+            'billing_scheme' => 'per_unit',
+            'amount' => 1000,
+            'product' => static::$productId,
+        ]);
+
+        Plan::create([
+            'id' => static::$premiumPlanId,
+            'nickname' => 'Monthly $20 Premium',
+            'currency' => 'USD',
+            'interval' => 'month',
+            'billing_scheme' => 'per_unit',
+            'amount' => 2000,
+            'product' => static::$productId,
+        ]);
+
+        static::$taxRateId = TaxRate::create([
+            'display_name' => 'VAT',
+            'description' => 'VAT Belgium',
+            'jurisdiction' => 'BE',
+            'percentage' => 21,
+            'inclusive' => false,
+        ])->id;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        static::deleteStripeResource(new Plan(static::$planId));
+        static::deleteStripeResource(new Plan(static::$otherPlanId));
+        static::deleteStripeResource(new Plan(static::$premiumPlanId));
+        static::deleteStripeResource(new Product(static::$productId));
+    }
+
+    public function test_customers_can_have_multiplan_subscriptions()
+    {
+        $user = $this->createCustomer('customers_can_have_multiplan_subscriptions');
+
+        $user->planTaxRates = [self::$otherPlanId => [self::$taxRateId]];
+
+        $subscription = $user->newSubscription('main', [self::$planId, self::$otherPlanId])
+            ->plan(self::$premiumPlanId, 5)
+            ->quantity(10, self::$planId)
+            ->create('pm_card_visa');
+
+        $this->assertTrue($user->subscribed('main', self::$planId));
+        $this->assertTrue($user->onPlan(self::$planId));
+
+        $item = $subscription->findItemOrFail(self::$planId);
+        $otherItem = $subscription->findItemOrFail(self::$otherPlanId);
+        $premiumItem = $subscription->findItemOrFail(self::$premiumPlanId);
+
+        $this->assertCount(3, $subscription->items);
+        $this->assertSame(self::$planId, $item->stripe_plan);
+        $this->assertSame(10, $item->quantity);
+        $this->assertSame(self::$otherPlanId, $otherItem->stripe_plan);
+        $this->assertSame(1, $otherItem->quantity);
+        $this->assertSame(self::$taxRateId, Arr::first($otherItem->asStripeSubscriptionItem()->tax_rates)->id);
+        $this->assertSame(self::$premiumPlanId, $premiumItem->stripe_plan);
+        $this->assertSame(5, $premiumItem->quantity);
+    }
+
+    public function test_customers_can_add_plans()
+    {
+        $user = $this->createCustomer('customers_can_add_plans');
+
+        $subscription = $user->newSubscription('main', self::$planId)->create('pm_card_visa');
+
+        $subscription->addPlan(self::$otherPlanId, 5);
+
+        $this->assertTrue($user->onPlan(self::$planId));
+        $this->assertFalse($user->onPlan(self::$premiumPlanId));
+
+        $item = $subscription->findItemOrFail(self::$planId);
+        $otherItem = $subscription->findItemOrFail(self::$otherPlanId);
+
+        $this->assertCount(2, $subscription->items);
+        $this->assertSame(self::$planId, $item->stripe_plan);
+        $this->assertSame(1, $item->quantity);
+        $this->assertSame(self::$otherPlanId, $otherItem->stripe_plan);
+        $this->assertSame(5, $otherItem->quantity);
+    }
+
+    public function test_customers_can_remove_plans()
+    {
+        $user = $this->createCustomer('customers_can_remove_plans');
+
+        $subscription = $user->newSubscription('main', [self::$planId, self::$otherPlanId])->create('pm_card_visa');
+
+        $this->assertCount(2, $subscription->items);
+
+        $subscription->removePlan(self::$planId);
+
+        $this->assertCount(1, $subscription->items);
+    }
+
+    public function test_customers_cannot_remove_the_last_plan()
+    {
+        $user = $this->createCustomer('customers_cannot_remove_the_last_plan');
+
+        $subscription = $this->createSubscriptionWithSinglePlan($user);
+
+        $this->expectException(SubscriptionUpdateFailure::class);
+
+        $subscription->removePlan(self::$planId);
+    }
+
+    public function test_plan_is_required_when_updating_quantities_for_multiplan_subscriptions()
+    {
+        $user = $this->createCustomer('plan_is_required_when_updating_quantities_for_multiplan_subscriptions');
+
+        $subscription = $this->createSubscriptionWithMultiplePlans($user);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $subscription->updateQuantity(5);
+    }
+
+    public function test_subscription_item_quantities_can_be_updated()
+    {
+        $user = $this->createCustomer('subscription_item_quantities_can_be_updated');
+
+        $subscription = $user->newSubscription('main', [self::$planId, self::$otherPlanId])->create('pm_card_visa');
+
+        $subscription->updateQuantity(5, self::$otherPlanId);
+
+        $item = $subscription->findItemOrFail(self::$otherPlanId);
+
+        $this->assertSame(5, $item->quantity);
+    }
+
+    public function test_plans_cannot_be_swapped_when_subscription_has_multiple_plans()
+    {
+        $user = $this->createCustomer('plans_cannot_be_swapped_when_subscription_has_multiple_plans');
+
+        $subscription = $this->createSubscriptionWithMultiplePlans($user);
+
+        $this->expectException(SubscriptionUpdateFailure::class);
+
+        $subscription->swap(self::$premiumPlanId);
+    }
+
+    public function test_subscription_item_changes_can_be_prorated()
+    {
+        $user = $this->createCustomer('subscription_item_changes_can_be_prorated');
+
+        $subscription = $user->newSubscription('main', static::$premiumPlanId)->create('pm_card_visa');
+
+        $this->assertEquals(2000, ($invoice = $user->invoices()->first())->rawTotal());
+
+        $subscription->noProrate()->addPlanAndInvoice(self::$otherPlanId);
+
+        // Assert that no new invoice was created because of no prorating.
+        $this->assertEquals($invoice->id, $user->invoices()->first()->id);
+
+        $subscription->prorate()->addPlanAndInvoice(self::$planId);
+
+        // Assert that a new invoice was created because of no prorating.
+        $this->assertEquals(1000, ($invoice = $user->invoices()->first())->rawTotal());
+
+        $subscription->noProrate()->removePlan(self::$premiumPlanId);
+
+        // Assert that no new invoice was created because of no prorating.
+        $this->assertEquals($invoice->id, $user->invoices()->first()->id);
+    }
+
+    /**
+     * Create a subscription with a single plan.
+     *
+     * @param  \Laravel\Cashier\Tests\Fixtures\User  $user
+     * @return \Laravel\Cashier\Subscription
+     */
+    protected function createSubscriptionWithSinglePlan(User $user)
+    {
+        $subscription = $user->subscriptions()->create([
+            'name' => 'main',
+            'stripe_id' => 'sub_foo',
+            'stripe_plan' => 'plan_foo',
+            'stripe_status' => 'active',
+        ]);
+
+        $subscription->items()->create([
+            'stripe_id' => 'it_foo',
+            'stripe_plan' => self::$planId,
+            'quantity' => 1,
+        ]);
+
+        return $subscription;
+    }
+
+    /**
+     * Create a subscription with multiple plans.
+     *
+     * @param  \Laravel\Cashier\Tests\Fixtures\User  $user
+     * @return \Laravel\Cashier\Subscription
+     */
+    protected function createSubscriptionWithMultiplePlans(User $user)
+    {
+        $subscription = $this->createSubscriptionWithSinglePlan($user);
+
+        $subscription->stripe_plan = null;
+        $subscription->save();
+
+        $subscription->items()->create([
+            'stripe_id' => 'it_foo',
+            'stripe_plan' => self::$otherPlanId,
+            'quantity' => 1,
+        ]);
+
+        return $subscription;
+    }
+}

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -12,6 +12,8 @@ class User extends Model
 
     public $taxRates = [];
 
+    public $planTaxRates = [];
+
     /**
      * Get the tax rates to apply to the subscription.
      *
@@ -20,5 +22,15 @@ class User extends Model
     public function taxRates()
     {
         return $this->taxRates;
+    }
+
+    /**
+     * Get the tax rates to apply to individual subscription items.
+     *
+     * @return array
+     */
+    public function planTaxRates()
+    {
+        return $this->planTaxRates;
     }
 }

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -102,4 +102,20 @@ class SubscriptionTest extends TestCase
 
         (new Subscription)->extendTrial(now()->subDay());
     }
+
+    public function test_we_can_check_if_it_has_a_single_plan()
+    {
+        $subscription = new Subscription(['stripe_plan' => 'foo']);
+
+        $this->assertTrue($subscription->hasSinglePlan());
+        $this->assertFalse($subscription->hasMultiplePlans());
+    }
+
+    public function test_we_can_check_if_it_has_multiple_plans()
+    {
+        $subscription = new Subscription(['stripe_plan' => null]);
+
+        $this->assertTrue($subscription->hasMultiplePlans());
+        $this->assertFalse($subscription->hasSinglePlan());
+    }
 }


### PR DESCRIPTION
This PR implements multiplan subscription support into Cashier.

Some examples:

```php
// Add a new plan to a subscription...
$subscription->addPlan($plan);

// Add a new plan to a subscription and invoice immediately...
$subscription->addPlanAndInvoice($plan);

// Add a new plan with a specific quantity...
$subscription->addPlan($plan, $quantity);

// Remove a plan from a subscription...
$subscription->removePlan($plan);

// Update quantities for plans...
$subscription->updateQuantity($quantity, $plan);
```

Stripe docs: https://stripe.com/docs/billing/subscriptions/multiplan
Stripe API: https://stripe.com/docs/api/subscription_items

Closes https://github.com/laravel/cashier/issues/397

### Todo

- [x] Update `swap` and `resume` methods on `Subscription` model
- [x] Update `onTrial`, `subscribed`, `subscribedTo` and `onPlan` methods on `ManagesSubscriptions` trait
- [x] Maybe introduce easy way of applying tax rates to individual subscription items?
- [x] Add new methods on `Subscription` model
- [x] Write tests