### PR TITLE
syncStripe method in Subscription class

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -156,6 +156,23 @@ class Subscription extends Model
     }
 
     /**
+     * Sync the Stripe subscription.
+     *
+     * @return void
+     */
+    public function syncStripe()
+    {
+        $subscription = $this->asStripeSubscription();
+
+        $this->stripe_status = $subscription->status;
+        $this->quantity = $subscription->quantity;
+        $this->trial_ends_at = $subscription->trial_end;
+        $this->ends_at = $subscription->ended_at;
+        
+        $this->save();
+    }
+    
+    /**
      * Sync the Stripe status of the subscription.
      *
      * @return void

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -168,7 +168,7 @@ class Subscription extends Model
         $this->quantity = $subscription->quantity;
         $this->trial_ends_at = $subscription->trial_end;
         $this->ends_at = $subscription->ended_at;
-        
+
         $this->save();
     }
     


### PR DESCRIPTION
New method "syncStripe" in Subscription class, to perform full synchronization. Motivation: active scope from subscriptions check status but also "ends_at" value (and ignore canceled status).

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
