### PR TITLE
[11.x] Implement new proration_behavior field

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -373,7 +373,7 @@ class Subscription extends Model
 
         $subscription->quantity = $quantity;
 
-        $subscription->prorate = $this->prorate;
+        $subscription->proration_behavior = $this->prorateBehavior();
 
         $subscription->save();
 
@@ -406,6 +406,16 @@ class Subscription extends Model
         $this->prorate = true;
 
         return $this;
+    }
+
+    /**
+     * Determine the prorating behavior when updating the subscription.
+     *
+     * @return string
+     */
+    public function prorateBehavior()
+    {
+        return $this->prorate ? 'create_prorations' : 'none';
     }
 
     /**
@@ -483,7 +493,7 @@ class Subscription extends Model
 
         $subscription->plan = $plan;
 
-        $subscription->prorate = $this->prorate;
+        $subscription->proration_behavior = $this->prorateBehavior();
 
         $subscription->cancel_at_period_end = false;
 


### PR DESCRIPTION
This updates the prorations of subscriptions with the new `proration_behavior` field. No breaking changes.

I've made the decision to not make use of the `always_invoice` value  and [pending updates](https://stripe.com/docs/billing/subscriptions/pending-updates) for now. I think we can apply that on the `swapAndInvoice` method but there's all sorts of complications when doing it which I'd rather investigate at a different time. 

Closes https://github.com/laravel/cashier/issues/902