### PR TITLE
[11.x] Multiplan swapping

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -11,7 +11,7 @@ trait ManagesSubscriptions
      * Begin creating a new subscription.
      *
      * @param  string  $name
-     * @param  string|array  $plans
+     * @param  string|string[]  $plans
      * @return \Laravel\Cashier\SubscriptionBuilder
      */
     public function newSubscription($name, $plans)
@@ -112,7 +112,7 @@ trait ManagesSubscriptions
     /**
      * Determine if the Stripe model is actively subscribed to one of the given plans.
      *
-     * @param  array|string  $plans
+     * @param  string|string[]  $plans
      * @param  string  $name
      * @return bool
      */

--- a/src/Concerns/Prorates.php
+++ b/src/Concerns/Prorates.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Laravel\Cashier\Concerns;
+
+trait Prorates
+{
+    /**
+     * Indicates if the plan change should be prorated.
+     *
+     * @var bool
+     */
+    protected $prorate = true;
+
+    /**
+     * Indicate that the plan change should not be prorated.
+     *
+     * @return $this
+     */
+    public function noProrate()
+    {
+        $this->prorate = false;
+
+        return $this;
+    }
+
+    /**
+     * Indicate that the plan change should be prorated.
+     *
+     * @return $this
+     */
+    public function prorate()
+    {
+        $this->prorate = true;
+
+        return $this;
+    }
+
+    /**
+     * Determine the prorating behavior when updating the subscription.
+     *
+     * @return string
+     */
+    public function prorateBehavior()
+    {
+        return $this->prorate ? 'create_prorations' : 'none';
+    }
+}

--- a/src/Exceptions/SubscriptionUpdateFailure.php
+++ b/src/Exceptions/SubscriptionUpdateFailure.php
@@ -13,19 +13,6 @@ class SubscriptionUpdateFailure extends Exception
      * @param  \Laravel\Cashier\Subscription  $subscription
      * @return static
      */
-    public static function swapOnMultiplan(Subscription $subscription)
-    {
-        return new static(
-            "The subscription \"{$subscription->stripe_id}\" cannot be swapped because it has multiple plans."
-        );
-    }
-
-    /**
-     * Create a new SubscriptionUpdateFailure instance.
-     *
-     * @param  \Laravel\Cashier\Subscription  $subscription
-     * @return static
-     */
     public static function incompleteSubscription(Subscription $subscription)
     {
         return new static(

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -618,7 +618,7 @@ class Subscription extends Model
      */
     protected function parseSwapPlans($plans)
     {
-        $items = collect($plans)->mapWithKeys(function ($options, $plan) {
+        return collect($plans)->mapWithKeys(function ($options, $plan) {
             $plan = is_string($options) ? $options : $plan;
             $options = is_string($options) ? [] : $options;
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -560,7 +560,7 @@ class Subscription extends Model
             throw SubscriptionUpdateFailure::incompleteSubscription($this);
         }
 
-        $items = $this->mergePlansThatShouldBeDeletedDuringSwap(
+        $items = $this->mergeItemsThatShouldBeDeletedDuringSwap(
             $this->parseSwapPlans($plans)
         );
 

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -7,6 +7,7 @@ use Carbon\CarbonInterface;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use InvalidArgumentException;
+use Laravel\Cashier\Concerns\Prorates;
 use Laravel\Cashier\Exceptions\IncompletePayment;
 use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use LogicException;
@@ -14,6 +15,8 @@ use Stripe\Subscription as StripeSubscription;
 
 class Subscription extends Model
 {
+    use Prorates;
+
     /**
      * The attributes that are not mass assignable.
      *
@@ -46,13 +49,6 @@ class Subscription extends Model
         'trial_ends_at', 'ends_at',
         'created_at', 'updated_at',
     ];
-
-    /**
-     * Indicates if the plan change should be prorated.
-     *
-     * @var bool
-     */
-    protected $prorate = true;
 
     /**
      * The date on which the billing cycle should be anchored.
@@ -489,40 +485,6 @@ class Subscription extends Model
     }
 
     /**
-     * Indicate that the plan change should not be prorated.
-     *
-     * @return $this
-     */
-    public function noProrate()
-    {
-        $this->prorate = false;
-
-        return $this;
-    }
-
-    /**
-     * Indicate that the plan change should be prorated.
-     *
-     * @return $this
-     */
-    public function prorate()
-    {
-        $this->prorate = true;
-
-        return $this;
-    }
-
-    /**
-     * Determine the prorating behavior when updating the subscription.
-     *
-     * @return string
-     */
-    public function prorateBehavior()
-    {
-        return $this->prorate ? 'create_prorations' : 'none';
-    }
-
-    /**
      * Change the billing cycle anchor on a plan change.
      *
      * @param  \DateTimeInterface|int|string  $date
@@ -579,77 +541,101 @@ class Subscription extends Model
     }
 
     /**
-     * Swap the subscription to a new Stripe plan.
+     * Swap the subscription to new Stripe plans.
      *
-     * @param  string  $plan
-     * @param  array  $options
+     * @param  string|string[]  $plans
+     * @param  array  $subscriptionOptions
+     * @param  array  $planOptions
      * @return $this
      *
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
      */
-    public function swap($plan, $options = [])
+    public function swap($plans, $subscriptionOptions = [], $planOptions = [])
     {
-        if ($this->hasMultiplePlans()) {
-            throw SubscriptionUpdateFailure::swapOnMultiplan($this);
+        if (empty($plans = (array) $plans)) {
+            throw new InvalidArgumentException('Please provide at least one plan when swapping.');
         }
 
         if ($this->incomplete()) {
             throw SubscriptionUpdateFailure::incompleteSubscription($this);
         }
 
-        $subscription = $this->asStripeSubscription();
+        $items = collect($plans)->unique()->mapWithKeys(function ($plan) use ($planOptions) {
+            return [$plan =>array_merge([
+                'plan' => $plan,
+                'tax_rates' => $this->getPlanTaxRatesForPayload($plan),
+            ], $planOptions[$plan] ?? [])];
+        });
 
-        $subscription->plan = $plan;
-        $subscription->proration_behavior = $this->prorateBehavior();
-        $subscription->cancel_at_period_end = false;
+        /** @var \Stripe\SubscriptionItem $stripeSubscriptionItem */
+        foreach ($this->asStripeSubscription()->items->data as $stripeSubscriptionItem) {
+            $plan = $stripeSubscriptionItem->plan->id;
 
-        if (! is_null($this->billingCycleAnchor)) {
-            $subscription->billing_cycle_anchor = $this->billingCycleAnchor;
+            if (! $item = $items->get($plan, [])) {
+                $item['deleted'] = true;
+            }
+
+            $items->put($plan, $item + ['id' => $stripeSubscriptionItem->id]);
         }
 
-        foreach ($options as $key => $option) {
-            $subscription->$key = $option;
+        $options = array_merge([
+            'items' => $items->values()->all(),
+            'proration_behavior' => $this->prorateBehavior(),
+            'cancel_at_period_end' => false,
+        ], $subscriptionOptions);
+
+        if (! is_null($this->billingCycleAnchor)) {
+            $options['billing_cycle_anchor'] = $this->billingCycleAnchor;
         }
 
         // If no specific trial end date has been set, the default behavior should be
         // to maintain the current trial state, whether that is "active" or to run
         // the swap out with the exact number of days left on this current plan.
         if ($this->onTrial()) {
-            $subscription->trial_end = $this->trial_ends_at->getTimestamp();
+            $options['trial_end'] = $this->trial_ends_at->getTimestamp();
         } else {
-            $subscription->trial_end = 'now';
+            $options['trial_end'] = 'now';
         }
 
-        // Again, if no explicit quantity was set, the default behaviors should be to
-        // maintain the current quantity onto the new plan. This is a sensible one
-        // that should be the expected behavior for most developers with Stripe.
-        if ($this->quantity) {
-            $subscription->quantity = $this->quantity;
-        }
-
-        $subscription->save();
+        $stripeSubscription = StripeSubscription::update($this->stripe_id, $options, $this->owner->stripeOptions());
 
         $this->fill([
-            'stripe_plan' => $plan,
+            'stripe_plan' => $stripeSubscription->plan ? $stripeSubscription->plan->id : null,
+            'quantity' => $stripeSubscription->quantity,
             'ends_at' => null,
         ])->save();
+
+        foreach ($stripeSubscription->items as $item) {
+            $this->items()->updateOrCreate([
+                'stripe_id' => $item->id,
+            ], [
+                'stripe_plan' => $item->plan->id,
+                'quantity' => $item->quantity,
+            ]);
+        }
+
+        // Delete items that aren't attached to the subscription anymore...
+        $this->items()->whereNotIn('stripe_plan', $items->pluck('plan')->filter())->delete();
+
+        $this->unsetRelation('items');
 
         return $this;
     }
 
     /**
-     * Swap the subscription to a new Stripe plan, and invoice immediately.
+     * Swap the subscription to new Stripe plans, and invoice immediately.
      *
-     * @param  string  $plan
-     * @param  array  $options
+     * @param  string|string[]  $plans
+     * @param  array  $subscriptionOptions
+     * @param  array  $planOptions
      * @return $this
      *
      * @throws \Laravel\Cashier\Exceptions\IncompletePayment
      * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
      */
-    public function swapAndInvoice($plan, $options = [])
+    public function swapAndInvoice($plans, $subscriptionOptions = [], $planOptions = [])
     {
-        $subscription = $this->swap($plan, $options);
+        $subscription = $this->swap($plans, $subscriptionOptions, $planOptions);
 
         $this->invoice();
 
@@ -733,11 +719,11 @@ class Subscription extends Model
      */
     public function removePlan($plan)
     {
-        $item = $this->findItemOrFail($plan);
-
         if ($this->hasSinglePlan()) {
             throw SubscriptionUpdateFailure::cannotDeleteLastPlan($this);
         }
+
+        $item = $this->findItemOrFail($plan);
 
         $item->asStripeSubscriptionItem()->delete([
             'proration_behavior' => $this->prorateBehavior(),
@@ -911,7 +897,7 @@ class Subscription extends Model
      * @param  string  $plan
      * @return array|null
      */
-    protected function getPlanTaxRatesForPayload($plan)
+    public function getPlanTaxRatesForPayload($plan)
     {
         if ($taxRates = $this->owner->planTaxRates()) {
             return $taxRates[$plan] ?? null;

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -564,7 +564,7 @@ class Subscription extends Model
         );
 
         $stripeSubscription = StripeSubscription::update(
-            $this->stripe_id, $this->getSwapOptions($items), $this->owner->stripeOptions()
+            $this->stripe_id, $this->getSwapOptions($items, $options), $this->owner->stripeOptions()
         );
 
         $this->fill([
@@ -654,9 +654,10 @@ class Subscription extends Model
      * Get the options array for a swap operation.
      *
      * @param  \Illuminate\Support\Collection  $items
+     * @param  array  $options
      * @return array
      */
-    protected function getSwapOptions(Collection $items)
+    protected function getSwapOptions(Collection $items, $options)
     {
         $options = array_merge([
             'items' => $items->values()->all(),

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Laravel\Cashier\Concerns\Prorates;
 use Laravel\Cashier\Exceptions\IncompletePayment;

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -71,7 +71,7 @@ class SubscriptionBuilder
      *
      * @param  mixed  $owner
      * @param  string  $name
-     * @param  string|array  $plans
+     * @param  string|string[]  $plans
      * @return void
      */
     public function __construct($owner, $name, $plans = null)

--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -3,10 +3,17 @@
 namespace Laravel\Cashier;
 
 use Illuminate\Database\Eloquent\Model;
+use Laravel\Cashier\Concerns\Prorates;
+use Laravel\Cashier\Exceptions\SubscriptionUpdateFailure;
 use Stripe\SubscriptionItem as StripeSubscriptionItem;
 
+/**
+ * @property \Laravel\Cashier\Subscription|null $subscription
+ */
 class SubscriptionItem extends Model
 {
+    use Prorates;
+
     /**
      * The attributes that are not mass assignable.
      *
@@ -34,9 +41,71 @@ class SubscriptionItem extends Model
     }
 
     /**
+     * Swap the subscription item to a new Stripe plan.
+     *
+     * @param  string  $plan
+     * @param  array  $options
+     * @return $this
+     *
+     * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
+     */
+    public function swap($plan, $options = [])
+    {
+        if ($this->subscription->incomplete()) {
+            throw SubscriptionUpdateFailure::incompleteSubscription($this->subscription);
+        }
+
+        $options = array_merge([
+            'plan' => $plan,
+            'quantity' => $this->quantity,
+            'proration_behavior' => $this->prorateBehavior(),
+            'tax_rates' => $this->subscription->getPlanTaxRatesForPayload($plan),
+        ], $options);
+
+        $item = StripeSubscriptionItem::update(
+            $this->stripe_id,
+            $options,
+            $this->subscription->owner->stripeOptions()
+        );
+
+        $this->fill([
+            'stripe_plan' => $plan,
+            'quantity' => $item->quantity,
+        ])->save();
+
+        if ($this->subscription->hasSinglePlan()) {
+            $this->subscription->fill([
+                'stripe_plan' => $plan,
+                'quantity' => $item->quantity,
+            ])->save();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Swap the subscription item to a new Stripe plan, and invoice immediately.
+     *
+     * @param  string  $plan
+     * @param  array  $options
+     * @return $this
+     *
+     * @throws \Laravel\Cashier\Exceptions\IncompletePayment
+     * @throws \Laravel\Cashier\Exceptions\SubscriptionUpdateFailure
+     */
+    public function swapAndInvoice($plan, $options = [])
+    {
+        $item = $this->swap($plan, $options);
+
+        $this->subscription->invoice();
+
+        return $item;
+    }
+
+    /**
      * Get the subscription as a Stripe subscription item object.
      *
-     * @return \Stripe\SubscriptionItem
+     * @return StripeSubscriptionItem
      */
     public function asStripeSubscriptionItem()
     {

--- a/tests/Feature/MultiplanSubscriptionsTest.php
+++ b/tests/Feature/MultiplanSubscriptionsTest.php
@@ -205,13 +205,17 @@ class MultiplanSubscriptionsTest extends FeatureTestCase
 
         $subscription = $user->newSubscription('main', static::$planId)->create('pm_card_visa');
 
-        $subscription = $subscription->swap([static::$otherPlanId, static::$premiumPlanId]);
+        $subscription = $subscription->swap([static::$otherPlanId, static::$premiumPlanId => ['quantity' => 3]]);
 
         $plans = $subscription->items()->pluck('stripe_plan');
 
         $this->assertCount(2, $plans);
         $this->assertContains(self::$otherPlanId, $plans);
         $this->assertContains(self::$premiumPlanId, $plans);
+
+        $premiumPlan = $subscription->findItemOrFail(static::$premiumPlanId);
+
+        $this->assertEquals(3, $premiumPlan->quantity);
     }
 
     public function test_subscription_items_can_swap_plans()

--- a/tests/Feature/MultiplanSubscriptionsTest.php
+++ b/tests/Feature/MultiplanSubscriptionsTest.php
@@ -199,15 +199,35 @@ class MultiplanSubscriptionsTest extends FeatureTestCase
         $this->assertSame(5, $item->quantity);
     }
 
-    public function test_plans_cannot_be_swapped_when_subscription_has_multiple_plans()
+    public function test_multiple_plans_can_be_swapped()
     {
-        $user = $this->createCustomer('plans_cannot_be_swapped_when_subscription_has_multiple_plans');
+        $user = $this->createCustomer('multiple_plans_can_be_swapped');
 
-        $subscription = $this->createSubscriptionWithMultiplePlans($user);
+        $subscription = $user->newSubscription('main', static::$planId)->create('pm_card_visa');
 
-        $this->expectException(SubscriptionUpdateFailure::class);
+        $subscription = $subscription->swap([static::$otherPlanId, static::$premiumPlanId]);
 
-        $subscription->swap(self::$premiumPlanId);
+        $plans = $subscription->items()->pluck('stripe_plan');
+
+        $this->assertCount(2, $plans);
+        $this->assertContains(self::$otherPlanId, $plans);
+        $this->assertContains(self::$premiumPlanId, $plans);
+    }
+
+    public function test_subscription_items_can_swap_plans()
+    {
+        $user = $this->createCustomer('subscription_items_can_swap_plans');
+
+        $subscription = $user->newSubscription('main', static::$planId)->create('pm_card_visa');
+
+        $item = $subscription->items()->first()->swap(static::$otherPlanId, ['quantity' => 3]);
+
+        $subscription->refresh();
+
+        $this->assertCount(1, $subscription->items);
+        $this->assertSame(self::$otherPlanId, $subscription->stripe_plan);
+        $this->assertSame(self::$otherPlanId, $item->stripe_plan);
+        $this->assertSame(3, $item->quantity);
     }
 
     public function test_subscription_item_changes_can_be_prorated()
@@ -245,7 +265,8 @@ class MultiplanSubscriptionsTest extends FeatureTestCase
         $subscription = $user->subscriptions()->create([
             'name' => 'main',
             'stripe_id' => 'sub_foo',
-            'stripe_plan' => 'plan_foo',
+            'stripe_plan' => self::$planId,
+            'quantity' => 1,
             'stripe_status' => 'active',
         ]);
 
@@ -269,6 +290,7 @@ class MultiplanSubscriptionsTest extends FeatureTestCase
         $subscription = $this->createSubscriptionWithSinglePlan($user);
 
         $subscription->stripe_plan = null;
+        $subscription->quantity = null;
         $subscription->save();
 
         $subscription->items()->create([


### PR DESCRIPTION
This PR adds support for multiplan swapping.

```php
// Swap multiple plans at the same time...
$subscription->swap(['new-plan', 'other-plan']);

// Invoice immediately...
$subscription->swapAndInvoice(['new-plan', 'other-plan']);

// Provide extra subscription options...
$subscription->swap(
    ['new-plan', 'other-plan'],
    ['metadata' => ['key' => 'value']]
);

// Provide extra subscription item options...
$subscription->swap(
    ['new-plan' => ['quantity' => 5], 'other-plan'],
    ['metadata' => ['key' => 'value']]
);
```

Any old plan which isn't in the list during swapping will be removed from the subscription. Any existing plan will be kept.

You also swap individual subscription items:

```php
// Swap an individual subscription item's plan to a different one...
$subscription->findOrFail('my-plan')->swap('other-plan');

// Invoice immediately...
$subscription->findOrFail('my-plan')->swapAndInvoice('other-plan');
```

Closes https://github.com/laravel/cashier/issues/912