### PR TITLE
[11.x] Re-add tax percentage

### DIFF
--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -147,6 +147,17 @@ trait ManagesSubscriptions
     }
 
     /**
+     * Get the tax percentage to apply to the subscription.
+     *
+     * @return int|float
+     * @deprecated Please migrate to the new Tax Rates API.
+     */
+    public function taxPercentage()
+    {
+        return 0;
+    }
+
+    /**
      * Get the tax rates to apply to the subscription.
      *
      * @return array

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -905,6 +905,21 @@ class Subscription extends Model
     }
 
     /**
+     * Sync the tax percentage of the user to the subscription.
+     *
+     * @return void
+     * @deprecated Please migrate to the new Tax Rates API.
+     */
+    public function syncTaxPercentage()
+    {
+        $subscription = $this->asStripeSubscription();
+
+        $subscription->tax_percent = $this->user->taxPercentage();
+
+        $subscription->save();
+    }
+
+    /**
      * Sync the tax rates of the user to the subscription.
      *
      * @return void


### PR DESCRIPTION
After discussing with @themsaid we decided to re-add the old `taxPercentage` way of defining tax rates to make it easier for people to migrate. Tax Rates will remain the primary way of defining taxes and we won't re-add the `taxPercentage` to the documentation. All `taxPercentage` calls are also marked as deprecated.