### PR TITLE
[11.x] Fix quantity prorating

### DIFF
--- a/src/Concerns/Prorates.php
+++ b/src/Concerns/Prorates.php
@@ -36,6 +36,19 @@ trait Prorates
     }
 
     /**
+     * Set the prorating behavior.
+     *
+     * @param  bool  $prorate
+     * @return $this
+     */
+    public function setProrate($prorate)
+    {
+        $this->prorate = $prorate;
+
+        return $this;
+    }
+
+    /**
      * Determine the prorating behavior when updating the subscription.
      *
      * @return string

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -394,7 +394,7 @@ class Subscription extends Model
         $this->guardAgainstIncomplete();
 
         if ($plan) {
-            $this->findItemOrFail($plan)->incrementQuantity($count);
+            $this->findItemOrFail($plan)->setProrate($this->prorate)->incrementQuantity($count);
 
             return $this->refresh();
         }
@@ -421,7 +421,7 @@ class Subscription extends Model
         $this->guardAgainstIncomplete();
 
         if ($plan) {
-            $this->findItemOrFail($plan)->incrementQuantity($count);
+            $this->findItemOrFail($plan)->setProrate($this->prorate)->incrementQuantity($count);
 
             return $this->refresh();
         }
@@ -449,7 +449,7 @@ class Subscription extends Model
         $this->guardAgainstIncomplete();
 
         if ($plan) {
-            $this->findItemOrFail($plan)->decrementQuantity($count);
+            $this->findItemOrFail($plan)->setProrate($this->prorate)->decrementQuantity($count);
 
             return $this->refresh();
         }
@@ -473,7 +473,7 @@ class Subscription extends Model
         $this->guardAgainstIncomplete();
 
         if ($plan) {
-            $this->findItemOrFail($plan)->updateQuantity($quantity);
+            $this->findItemOrFail($plan)->setProrate($this->prorate)->updateQuantity($quantity);
 
             return $this->refresh();
         }

--- a/tests/Feature/MultiplanSubscriptionsTest.php
+++ b/tests/Feature/MultiplanSubscriptionsTest.php
@@ -294,6 +294,21 @@ class MultiplanSubscriptionsTest extends FeatureTestCase
         $this->assertEquals($invoice->id, $user->invoices()->first()->id);
     }
 
+    public function test_subscription_item_quantity_changes_can_be_prorated()
+    {
+        $user = $this->createCustomer('subscription_item_quantity_changes_can_be_prorated');
+
+        $subscription = $user->newSubscription('main', [self::$planId, self::$otherPlanId])
+            ->quantity(3, self::$otherPlanId)
+            ->create('pm_card_visa');
+
+        $this->assertEquals(4000, ($invoice = $user->invoices()->first())->rawTotal());
+
+        $subscription->noProrate()->updateQuantity(1, self::$otherPlanId);
+
+        $this->assertEquals(2000, $user->upcomingInvoice()->rawTotal());
+    }
+
     /**
      * Create a subscription with a single plan.
      *


### PR DESCRIPTION
Pass through the `$prorate` state of the subscription to the subscription item before doing the prorating.

Fixes https://github.com/laravel/cashier/issues/923