### PR TITLE
[11.x] Fix multiplan subscription swapping

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -864,11 +864,6 @@ class Subscription extends Model
 
         $subscription->cancel_at_period_end = false;
 
-        // To resume the subscription we need to set the plan parameter on the Stripe
-        // subscription object. This will force Stripe to resume this subscription
-        // where we left off. Then, we'll set the proper trial ending timestamp.
-        $subscription->plan = $this->stripe_plan;
-
         if ($this->onTrial()) {
             $subscription->trial_end = $this->trial_ends_at->getTimestamp();
         } else {

--- a/tests/Feature/MultiplanSubscriptionsTest.php
+++ b/tests/Feature/MultiplanSubscriptionsTest.php
@@ -175,6 +175,23 @@ class MultiplanSubscriptionsTest extends FeatureTestCase
         $subscription->removePlan(self::$planId);
     }
 
+    public function test_multiplan_subscriptions_can_be_resumed()
+    {
+        $user = $this->createCustomer('multiplan_subscriptions_can_be_resumed');
+
+        $subscription = $user->newSubscription('main', [self::$planId, self::$otherPlanId])->create('pm_card_visa');
+
+        $subscription->cancel();
+
+        $this->assertTrue($subscription->active());
+        $this->assertTrue($subscription->onGracePeriod());
+
+        $subscription->resume();
+
+        $this->assertTrue($subscription->active());
+        $this->assertFalse($subscription->onGracePeriod());
+    }
+
     public function test_plan_is_required_when_updating_quantities_for_multiplan_subscriptions()
     {
         $user = $this->createCustomer('plan_is_required_when_updating_quantities_for_multiplan_subscriptions');


### PR DESCRIPTION
As suspected, the plan parameter here is causing some issues for multiplan subscriptions. I think it can be safely removed without affecting existing code. 

Added a test that verifies resuming canceled multiplan subscriptions.

Fixes https://github.com/laravel/cashier/issues/921