### PR TITLE
Use sendInvoice() when collection method is 'send_invoice'

### DIFF
--- a/src/Concerns/ManagesInvoices.php
+++ b/src/Concerns/ManagesInvoices.php
@@ -76,7 +76,11 @@ trait ManagesInvoices
             /** @var \Stripe\Invoice $invoice */
             $stripeInvoice = StripeInvoice::create($parameters, $this->stripeOptions());
 
-            $stripeInvoice = $stripeInvoice->pay();
+            if ($stripeInvoice->collection_method == 'charge_automatically') {
+                $stripeInvoice = $stripeInvoice->pay();
+            } else {
+                $stripeInvoice = $stripeInvoice->sendInvoice();
+            }
 
             return new Invoice($this, $stripeInvoice);
         } catch (StripeInvalidRequestException $exception) {


### PR DESCRIPTION
In some edge cases (like mine) we have clients that can't use a credit card, but we still want to have all the data in Stripe. So we create a subscription with collection_method = 'send_invoice' and the manually sent the invoices to be paid, once we received payment we just change the status manually in Stripe.

```
$model->invoice(['collection_method' => 'send_invoice']);
$subscription->invoice(['collection_method' => 'send_invoice']);
```

When you use this collection method you can't apply `$stripeInvoice->pay()` function, you need to use the `$stripeInvoice->sendInvoice();`

When using the `$stripeInvoice->pay()` on when a colletion_method is 'send_invoice' it throws PaymentFailure, 'send_invoice' it doesn't require a payment method.

The only two options in 'collection_methods' are charge_automatically (default) or 'send_invoice' therefore using a simple if-else statement.

https://stripe.com/docs/api/invoices/create#create_invoice-collection_method

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
