### PR TITLE
Expand option to asStripeSubscriptionItem method

### DIFF
--- a/src/SubscriptionItem.php
+++ b/src/SubscriptionItem.php
@@ -183,12 +183,13 @@ class SubscriptionItem extends Model
     /**
      * Get the subscription as a Stripe subscription item object.
      *
+     * @param  array  $expand
      * @return StripeSubscriptionItem
      */
-    public function asStripeSubscriptionItem()
+    public function asStripeSubscriptionItem(array $expand = [])
     {
         return StripeSubscriptionItem::retrieve(
-            $this->stripe_id,
+            ['id' => $this->stripe_id, 'expand' => $expand],
             $this->subscription->owner->stripeOptions()
         );
     }


### PR DESCRIPTION
Enable the option to expand the SubscriptionItem::retrieve as you can with the asStripeSubscription method.

My use case is to be able to expand the plan's product to retrieve the name of the related product. I think this will be helpful when listing multiple subscription items on the "billing page" and want to display the actual product names related to each subscription item. The response from Stripe API is only the product id, which is not that descriptive for the user.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
