### PR TITLE
[12.x] Rename all subscription boolean method with `is` as prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/laravel/cashier/compare/v11.2.4...master)
 
+### Changed
+- Renamed all Subscription boolean method with a `is` prefix. ([#940](https://github.com/laravel/cashier/issues/940))
 
 ## [v11.2.4 (2020-05-08)](https://github.com/laravel/cashier/compare/v11.2.4...v11.2.4)
 

--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -34,7 +34,7 @@ trait ManagesSubscriptions
 
         $subscription = $this->subscription($name);
 
-        if (! $subscription || ! $subscription->onTrial()) {
+        if (! $subscription || ! $subscription->isOnTrial()) {
             return false;
         }
 

--- a/src/Concerns/ManagesSubscriptions.php
+++ b/src/Concerns/ManagesSubscriptions.php
@@ -26,9 +26,9 @@ trait ManagesSubscriptions
      * @param  string|null  $plan
      * @return bool
      */
-    public function onTrial($name = 'default', $plan = null)
+    public function isOnTrial($name = 'default', $plan = null)
     {
-        if (func_num_args() === 0 && $this->onGenericTrial()) {
+        if (func_num_args() === 0 && $this->isOnGenericTrial()) {
             return true;
         }
 
@@ -46,7 +46,7 @@ trait ManagesSubscriptions
      *
      * @return bool
      */
-    public function onGenericTrial()
+    public function isOnGenericTrial()
     {
         return $this->trial_ends_at && $this->trial_ends_at->isFuture();
     }
@@ -62,7 +62,7 @@ trait ManagesSubscriptions
     {
         $subscription = $this->subscription($name);
 
-        if (! $subscription || ! $subscription->valid()) {
+        if (! $subscription || ! $subscription->isValid()) {
             return false;
         }
 
@@ -120,7 +120,7 @@ trait ManagesSubscriptions
     {
         $subscription = $this->subscription($name);
 
-        if (! $subscription || ! $subscription->valid()) {
+        if (! $subscription || ! $subscription->isValid()) {
             return false;
         }
 
@@ -142,7 +142,7 @@ trait ManagesSubscriptions
     public function onPlan($plan)
     {
         return ! is_null($this->subscriptions->first(function (Subscription $subscription) use ($plan) {
-            return $subscription->valid() && $subscription->hasPlan($plan);
+            return $subscription->isValid() && $subscription->hasPlan($plan);
         }));
     }
 

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -93,7 +93,7 @@ class WebhookController extends Controller
                 // Cancellation date...
                 if (isset($data['cancel_at_period_end'])) {
                     if ($data['cancel_at_period_end']) {
-                        $subscription->ends_at = $subscription->onTrial()
+                        $subscription->ends_at = $subscription->isOnTrial()
                             ? $subscription->trial_ends_at
                             : Carbon::createFromTimestamp($data['current_period_end']);
                     } else {

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -145,7 +145,7 @@ class Subscription extends Model
      *
      * @return bool
      */
-    public function valid()
+    public function isValid()
     {
         return $this->isActive() || $this->isOnTrial() || $this->isOnGracePeriod();
     }

--- a/src/SubscriptionBuilder.php
+++ b/src/SubscriptionBuilder.php
@@ -275,7 +275,7 @@ class SubscriptionBuilder
             ]);
         }
 
-        if ($subscription->incomplete()) {
+        if ($subscription->isIncomplete()) {
             (new Payment(
                 $stripeSubscription->latest_invoice->payment_intent
             ))->validate();

--- a/tests/Feature/MultiplanSubscriptionsTest.php
+++ b/tests/Feature/MultiplanSubscriptionsTest.php
@@ -183,13 +183,13 @@ class MultiplanSubscriptionsTest extends FeatureTestCase
 
         $subscription->cancel();
 
-        $this->assertTrue($subscription->active());
-        $this->assertTrue($subscription->onGracePeriod());
+        $this->assertTrue($subscription->isActive());
+        $this->assertTrue($subscription->isOnGracePeriod());
 
         $subscription->resume();
 
-        $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->onGracePeriod());
+        $this->assertTrue($subscription->isActive());
+        $this->assertFalse($subscription->isOnGracePeriod());
     }
 
     public function test_plan_is_required_when_updating_quantities_for_multiplan_subscriptions()

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -422,6 +422,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertFalse($subscription->isRecurring());
         $this->assertFalse($subscription->isEnded());
         $this->assertEquals(Carbon::today()->addDays(7)->day, $subscription->trial_ends_at->day);
+        $this->assertTrue($user->isOnTrial('main'));
 
         // Cancel Subscription
         $subscription->cancel();
@@ -440,6 +441,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertFalse($subscription->isRecurring());
         $this->assertFalse($subscription->isEnded());
         $this->assertEquals(Carbon::today()->addDays(7)->day, $subscription->trial_ends_at->day);
+        $this->assertTrue($user->isOnTrial('main'));
     }
 
     public function test_creating_subscription_with_explicit_trial()
@@ -622,6 +624,7 @@ class SubscriptionsTest extends FeatureTestCase
 
         $this->assertTrue($subscription->isActive());
         $this->assertTrue($user->subscriptions()->active()->exists());
+        $this->assertTrue($user->subscriptions()->pastDue()->exists());
 
         // Reset deactivate past due state to default to not conflict with other tests.
         Cashier::$deactivatePastDue = true;

--- a/tests/Feature/SubscriptionsTest.php
+++ b/tests/Feature/SubscriptionsTest.php
@@ -139,42 +139,42 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertFalse($user->subscribedToPlan(static::$otherPlanId, 'main'));
         $this->assertTrue($user->subscribed('main', static::$planId));
         $this->assertFalse($user->subscribed('main', static::$otherPlanId));
-        $this->assertTrue($user->subscription('main')->active());
-        $this->assertFalse($user->subscription('main')->cancelled());
-        $this->assertFalse($user->subscription('main')->onGracePeriod());
-        $this->assertTrue($user->subscription('main')->recurring());
-        $this->assertFalse($user->subscription('main')->ended());
+        $this->assertTrue($user->subscription('main')->isActive());
+        $this->assertFalse($user->subscription('main')->isCancelled());
+        $this->assertFalse($user->subscription('main')->isOnGracePeriod());
+        $this->assertTrue($user->subscription('main')->isRecurring());
+        $this->assertFalse($user->subscription('main')->isEnded());
 
         // Cancel Subscription
         $subscription = $user->subscription('main');
         $subscription->cancel();
 
-        $this->assertTrue($subscription->active());
-        $this->assertTrue($subscription->cancelled());
-        $this->assertTrue($subscription->onGracePeriod());
-        $this->assertFalse($subscription->recurring());
-        $this->assertFalse($subscription->ended());
+        $this->assertTrue($subscription->isActive());
+        $this->assertTrue($subscription->isCancelled());
+        $this->assertTrue($subscription->isOnGracePeriod());
+        $this->assertFalse($subscription->isRecurring());
+        $this->assertFalse($subscription->isEnded());
 
         // Modify Ends Date To Past
         $oldGracePeriod = $subscription->ends_at;
         $subscription->fill(['ends_at' => Carbon::now()->subDays(5)])->save();
 
-        $this->assertFalse($subscription->active());
-        $this->assertTrue($subscription->cancelled());
-        $this->assertFalse($subscription->onGracePeriod());
-        $this->assertFalse($subscription->recurring());
-        $this->assertTrue($subscription->ended());
+        $this->assertFalse($subscription->isActive());
+        $this->assertTrue($subscription->isCancelled());
+        $this->assertFalse($subscription->isOnGracePeriod());
+        $this->assertFalse($subscription->isRecurring());
+        $this->assertTrue($subscription->isEnded());
 
         $subscription->fill(['ends_at' => $oldGracePeriod])->save();
 
         // Resume Subscription
         $subscription->resume();
 
-        $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->cancelled());
-        $this->assertFalse($subscription->onGracePeriod());
-        $this->assertTrue($subscription->recurring());
-        $this->assertFalse($subscription->ended());
+        $this->assertTrue($subscription->isActive());
+        $this->assertFalse($subscription->isCancelled());
+        $this->assertFalse($subscription->isOnGracePeriod());
+        $this->assertTrue($subscription->isRecurring());
+        $this->assertFalse($subscription->isEnded());
 
         // Increment & Decrement
         $subscription->incrementQuantity();
@@ -229,7 +229,7 @@ class SubscriptionsTest extends FeatureTestCase
             $this->assertInstanceOf(Subscription::class, $subscription = $user->subscription('main'));
 
             // Assert subscription is incomplete.
-            $this->assertTrue($subscription->incomplete());
+            $this->assertTrue($subscription->isIncomplete());
         }
     }
 
@@ -249,7 +249,7 @@ class SubscriptionsTest extends FeatureTestCase
             $this->assertInstanceOf(Subscription::class, $subscription = $user->subscription('main'));
 
             // Assert subscription is incomplete.
-            $this->assertTrue($subscription->incomplete());
+            $this->assertTrue($subscription->isIncomplete());
         }
     }
 
@@ -275,7 +275,7 @@ class SubscriptionsTest extends FeatureTestCase
             $this->assertEquals(static::$premiumPlanId, $subscription->refresh()->stripe_plan);
 
             // Assert subscription is past due.
-            $this->assertTrue($subscription->pastDue());
+            $this->assertTrue($subscription->isPastDue());
         }
     }
 
@@ -301,7 +301,7 @@ class SubscriptionsTest extends FeatureTestCase
             $this->assertEquals(static::$premiumPlanId, $subscription->refresh()->stripe_plan);
 
             // Assert subscription is past due.
-            $this->assertTrue($subscription->pastDue());
+            $this->assertTrue($subscription->isPastDue());
         }
     }
 
@@ -321,7 +321,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertEquals(static::$planId, $subscription->refresh()->stripe_plan);
 
         // Assert subscription is still active.
-        $this->assertTrue($subscription->active());
+        $this->assertTrue($subscription->isActive());
     }
 
     public function test_downgrade_with_3d_secure_does_not_incomplete_subscription()
@@ -340,7 +340,7 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertEquals(static::$planId, $subscription->refresh()->stripe_plan);
 
         // Assert subscription is still active.
-        $this->assertTrue($subscription->active());
+        $this->assertTrue($subscription->isActive());
     }
 
     public function test_creating_subscription_with_coupons()
@@ -357,11 +357,11 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscribed('main'));
         $this->assertTrue($user->subscribed('main', static::$planId));
         $this->assertFalse($user->subscribed('main', static::$otherPlanId));
-        $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->cancelled());
-        $this->assertFalse($subscription->onGracePeriod());
-        $this->assertTrue($subscription->recurring());
-        $this->assertFalse($subscription->ended());
+        $this->assertTrue($subscription->isActive());
+        $this->assertFalse($subscription->isCancelled());
+        $this->assertFalse($subscription->isOnGracePeriod());
+        $this->assertTrue($subscription->isRecurring());
+        $this->assertFalse($subscription->isEnded());
 
         // Invoice Tests
         $invoice = $user->invoices()[0];
@@ -386,11 +386,11 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscribed('main'));
         $this->assertTrue($user->subscribed('main', static::$planId));
         $this->assertFalse($user->subscribed('main', static::$otherPlanId));
-        $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->cancelled());
-        $this->assertFalse($subscription->onGracePeriod());
-        $this->assertTrue($subscription->recurring());
-        $this->assertFalse($subscription->ended());
+        $this->assertTrue($subscription->isActive());
+        $this->assertFalse($subscription->isCancelled());
+        $this->assertFalse($subscription->isOnGracePeriod());
+        $this->assertTrue($subscription->isRecurring());
+        $this->assertFalse($subscription->isEnded());
 
         // Invoice Tests
         $invoice = $user->invoices()[0];
@@ -417,28 +417,28 @@ class SubscriptionsTest extends FeatureTestCase
 
         $subscription = $user->subscription('main');
 
-        $this->assertTrue($subscription->active());
-        $this->assertTrue($subscription->onTrial());
-        $this->assertFalse($subscription->recurring());
-        $this->assertFalse($subscription->ended());
+        $this->assertTrue($subscription->isActive());
+        $this->assertTrue($subscription->isOnTrial());
+        $this->assertFalse($subscription->isRecurring());
+        $this->assertFalse($subscription->isEnded());
         $this->assertEquals(Carbon::today()->addDays(7)->day, $subscription->trial_ends_at->day);
 
         // Cancel Subscription
         $subscription->cancel();
 
-        $this->assertTrue($subscription->active());
-        $this->assertTrue($subscription->onGracePeriod());
-        $this->assertFalse($subscription->recurring());
-        $this->assertFalse($subscription->ended());
+        $this->assertTrue($subscription->isActive());
+        $this->assertTrue($subscription->isOnGracePeriod());
+        $this->assertFalse($subscription->isRecurring());
+        $this->assertFalse($subscription->isEnded());
 
         // Resume Subscription
         $subscription->resume();
 
-        $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->onGracePeriod());
-        $this->assertTrue($subscription->onTrial());
-        $this->assertFalse($subscription->recurring());
-        $this->assertFalse($subscription->ended());
+        $this->assertTrue($subscription->isActive());
+        $this->assertFalse($subscription->isOnGracePeriod());
+        $this->assertTrue($subscription->isOnTrial());
+        $this->assertFalse($subscription->isRecurring());
+        $this->assertFalse($subscription->isEnded());
         $this->assertEquals(Carbon::today()->addDays(7)->day, $subscription->trial_ends_at->day);
     }
 
@@ -453,28 +453,28 @@ class SubscriptionsTest extends FeatureTestCase
 
         $subscription = $user->subscription('main');
 
-        $this->assertTrue($subscription->active());
-        $this->assertTrue($subscription->onTrial());
-        $this->assertFalse($subscription->recurring());
-        $this->assertFalse($subscription->ended());
+        $this->assertTrue($subscription->isActive());
+        $this->assertTrue($subscription->isOnTrial());
+        $this->assertFalse($subscription->isRecurring());
+        $this->assertFalse($subscription->isEnded());
         $this->assertEquals(Carbon::tomorrow()->hour(3)->minute(15), $subscription->trial_ends_at);
 
         // Cancel Subscription
         $subscription->cancel();
 
-        $this->assertTrue($subscription->active());
-        $this->assertTrue($subscription->onGracePeriod());
-        $this->assertFalse($subscription->recurring());
-        $this->assertFalse($subscription->ended());
+        $this->assertTrue($subscription->isActive());
+        $this->assertTrue($subscription->isOnGracePeriod());
+        $this->assertFalse($subscription->isRecurring());
+        $this->assertFalse($subscription->isEnded());
 
         // Resume Subscription
         $subscription->resume();
 
-        $this->assertTrue($subscription->active());
-        $this->assertFalse($subscription->onGracePeriod());
-        $this->assertTrue($subscription->onTrial());
-        $this->assertFalse($subscription->recurring());
-        $this->assertFalse($subscription->ended());
+        $this->assertTrue($subscription->isActive());
+        $this->assertFalse($subscription->isOnGracePeriod());
+        $this->assertTrue($subscription->isOnTrial());
+        $this->assertFalse($subscription->isRecurring());
+        $this->assertFalse($subscription->isEnded());
         $this->assertEquals(Carbon::tomorrow()->hour(3)->minute(15), $subscription->trial_ends_at);
     }
 
@@ -613,14 +613,14 @@ class SubscriptionsTest extends FeatureTestCase
         $this->assertTrue($user->subscriptions()->ended()->exists());
 
         // Enable past_due as active state.
-        $this->assertFalse($subscription->active());
+        $this->assertFalse($subscription->isActive());
         $this->assertFalse($user->subscriptions()->active()->exists());
 
         Cashier::keepPastDueSubscriptionsActive();
 
         $subscription->update(['ends_at' => null, 'stripe_status' => StripeSubscription::STATUS_PAST_DUE]);
 
-        $this->assertTrue($subscription->active());
+        $this->assertTrue($subscription->isActive());
         $this->assertTrue($user->subscriptions()->active()->exists());
 
         // Reset deactivate past due state to default to not conflict with other tests.

--- a/tests/Feature/WebhooksTest.php
+++ b/tests/Feature/WebhooksTest.php
@@ -115,7 +115,7 @@ class WebhooksTest extends FeatureTestCase
         $subscription = $user->newSubscription('main', static::$planId)->create('pm_card_visa');
         $subscription->cancel();
 
-        $this->assertTrue($subscription->cancelled());
+        $this->assertTrue($subscription->isCancelled());
 
         $this->postJson('stripe/webhook', [
             'id' => 'foo',
@@ -130,7 +130,7 @@ class WebhooksTest extends FeatureTestCase
             ],
         ])->assertOk();
 
-        $this->assertFalse($subscription->fresh()->cancelled(), 'Subscription is still cancelled.');
+        $this->assertFalse($subscription->fresh()->isCancelled(), 'Subscription is still cancelled.');
     }
 
     public function test_subscription_is_marked_as_cancelled_when_deleted_in_stripe()
@@ -138,7 +138,7 @@ class WebhooksTest extends FeatureTestCase
         $user = $this->createCustomer('subscription_is_marked_as_cancelled_when_deleted_in_stripe');
         $subscription = $user->newSubscription('main', static::$planId)->create('pm_card_visa');
 
-        $this->assertFalse($subscription->cancelled());
+        $this->assertFalse($subscription->isCancelled());
 
         $this->postJson('stripe/webhook', [
             'id' => 'foo',
@@ -152,7 +152,7 @@ class WebhooksTest extends FeatureTestCase
             ],
         ])->assertOk();
 
-        $this->assertTrue($subscription->fresh()->cancelled(), 'Subscription is still active.');
+        $this->assertTrue($subscription->fresh()->isCancelled(), 'Subscription is still active.');
     }
 
     public function test_subscription_is_deleted_when_status_is_incomplete_expired()

--- a/tests/Unit/CustomerTest.php
+++ b/tests/Unit/CustomerTest.php
@@ -14,15 +14,15 @@ class CustomerTest extends TestCase
     {
         $user = new User;
 
-        $this->assertFalse($user->onGenericTrial());
+        $this->assertFalse($user->isOnGenericTrial());
 
         $user->trial_ends_at = Carbon::tomorrow();
 
-        $this->assertTrue($user->onGenericTrial());
+        $this->assertTrue($user->isOnGenericTrial());
 
         $user->trial_ends_at = Carbon::today()->subDays(5);
 
-        $this->assertFalse($user->onGenericTrial());
+        $this->assertFalse($user->isOnGenericTrial());
     }
 
     public function test_we_can_determine_if_it_has_a_payment_method()

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -40,21 +40,21 @@ class SubscriptionTest extends TestCase
     {
         $subscription = new Subscription(['stripe_status' => 'incomplete']);
 
-        $this->assertFalse($subscription->valid());
+        $this->assertFalse($subscription->isValid());
     }
 
     public function test_a_past_due_subscription_is_not_valid()
     {
         $subscription = new Subscription(['stripe_status' => 'past_due']);
 
-        $this->assertFalse($subscription->valid());
+        $this->assertFalse($subscription->isValid());
     }
 
     public function test_an_active_subscription_is_valid()
     {
         $subscription = new Subscription(['stripe_status' => 'active']);
 
-        $this->assertTrue($subscription->valid());
+        $this->assertTrue($subscription->isValid());
     }
 
     public function test_payment_is_incomplete_when_status_is_incomplete()

--- a/tests/Unit/SubscriptionTest.php
+++ b/tests/Unit/SubscriptionTest.php
@@ -13,27 +13,27 @@ class SubscriptionTest extends TestCase
     {
         $subscription = new Subscription(['stripe_status' => 'incomplete']);
 
-        $this->assertTrue($subscription->incomplete());
-        $this->assertFalse($subscription->pastDue());
-        $this->assertFalse($subscription->active());
+        $this->assertTrue($subscription->isIncomplete());
+        $this->assertFalse($subscription->isPastDue());
+        $this->assertFalse($subscription->isActive());
     }
 
     public function test_we_can_check_if_a_subscription_is_past_due()
     {
         $subscription = new Subscription(['stripe_status' => 'past_due']);
 
-        $this->assertFalse($subscription->incomplete());
-        $this->assertTrue($subscription->pastDue());
-        $this->assertFalse($subscription->active());
+        $this->assertFalse($subscription->isIncomplete());
+        $this->assertTrue($subscription->isPastDue());
+        $this->assertFalse($subscription->isActive());
     }
 
     public function test_we_can_check_if_a_subscription_is_active()
     {
         $subscription = new Subscription(['stripe_status' => 'active']);
 
-        $this->assertFalse($subscription->incomplete());
-        $this->assertFalse($subscription->pastDue());
-        $this->assertTrue($subscription->active());
+        $this->assertFalse($subscription->isIncomplete());
+        $this->assertFalse($subscription->isPastDue());
+        $this->assertTrue($subscription->isActive());
     }
 
     public function test_an_incomplete_subscription_is_not_valid()


### PR DESCRIPTION
Resolve #940 breaking back-compatibility
The method names now are clear and you can use scope methods like Laravel standard.

This pull request is against the master because it requires a Major version (#which-branch)[https://laravel.com/docs/contributions#which-branch] 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
