### PR TITLE
[12.x] Stripe Customer Portal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/view": "^6.0|^7.0",
         "moneyphp/money": "^3.2",
         "nesbot/carbon": "^2.0",
-        "stripe/stripe-php": "^7.0",
+        "stripe/stripe-php": "^7.29",
         "symfony/http-kernel": "^4.3|^5.0",
         "symfony/intl": "^4.3|^5.0"
     },

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Cashier\Concerns;
 
+use Illuminate\Http\RedirectResponse;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Exceptions\CustomerAlreadyCreated;
 use Laravel\Cashier\Exceptions\InvalidCustomer;
@@ -167,6 +168,19 @@ trait ManagesCustomer
             'customer' => $this->stripeId(),
             'return_url' => $returnUrl ?? route('home'),
         ], $this->stripeOptions())['url'];
+    }
+
+    /**
+     * Generate a redirect response to the customer's Stripe customer portal.
+     *
+     * @param  string|null  $returnUrl
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function redirectToCustomerPortal($returnUrl = null)
+    {
+        return new RedirectResponse(
+            $this->customerPortalUrl($returnUrl)
+        );
     }
 
     /**

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -5,6 +5,7 @@ namespace Laravel\Cashier\Concerns;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Exceptions\CustomerAlreadyCreated;
 use Laravel\Cashier\Exceptions\InvalidCustomer;
+use Stripe\BillingPortal\Session as StripeBillingPortalSession;
 use Stripe\Customer as StripeCustomer;
 
 trait ManagesCustomer
@@ -150,6 +151,22 @@ trait ManagesCustomer
     public function preferredCurrency()
     {
         return config('cashier.currency');
+    }
+
+    /**
+     * Get the Stripe customer portal for this customer.
+     *
+     * @param  string|null  $returnUrl
+     * @return string
+     */
+    public function customerPortalUrl($returnUrl = null)
+    {
+        $this->assertCustomerExists();
+
+        return StripeBillingPortalSession::create([
+            'customer' => $this->stripeId(),
+            'return_url' => $returnUrl ?? route('home'),
+        ], $this->stripeOptions())['url'];
     }
 
     /**

--- a/src/Concerns/ManagesCustomer.php
+++ b/src/Concerns/ManagesCustomer.php
@@ -155,12 +155,12 @@ trait ManagesCustomer
     }
 
     /**
-     * Get the Stripe customer portal for this customer.
+     * Get the Stripe billing portal for this customer.
      *
      * @param  string|null  $returnUrl
      * @return string
      */
-    public function customerPortalUrl($returnUrl = null)
+    public function billingPortalUrl($returnUrl = null)
     {
         $this->assertCustomerExists();
 
@@ -171,15 +171,15 @@ trait ManagesCustomer
     }
 
     /**
-     * Generate a redirect response to the customer's Stripe customer portal.
+     * Generate a redirect response to the customer's Stripe billing portal.
      *
      * @param  string|null  $returnUrl
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function redirectToCustomerPortal($returnUrl = null)
+    public function redirectToBillingPortal($returnUrl = null)
     {
         return new RedirectResponse(
-            $this->customerPortalUrl($returnUrl)
+            $this->billingPortalUrl($returnUrl)
         );
     }
 

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Cashier\Tests\Feature;
 
+use Illuminate\Http\RedirectResponse;
+
 class CustomerTest extends FeatureTestCase
 {
     public function test_customers_in_stripe_can_be_updated()
@@ -14,7 +16,7 @@ class CustomerTest extends FeatureTestCase
         $this->assertEquals('Mohamed Said', $customer->description);
     }
 
-    public function test_customers_can_visit_their_customer_portal()
+    public function test_customers_can_generate_a_customer_portal_url()
     {
         $user = $this->createCustomer('customers_in_stripe_can_be_updated');
         $user->createAsStripeCustomer();
@@ -22,5 +24,16 @@ class CustomerTest extends FeatureTestCase
         $url = $user->customerPortalUrl('https://example.com');
 
         $this->assertStringStartsWith('https://billing.stripe.com/session/', $url);
+    }
+
+    public function test_customers_can_be_redirected_to_their_customer_portal()
+    {
+        $user = $this->createCustomer('customers_in_stripe_can_be_updated');
+        $user->createAsStripeCustomer();
+
+        $response = $user->redirectToCustomerPortal('https://example.com');
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertStringStartsWith('https://billing.stripe.com/session/', $response->getTargetUrl());
     }
 }

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -13,4 +13,14 @@ class CustomerTest extends FeatureTestCase
 
         $this->assertEquals('Mohamed Said', $customer->description);
     }
+
+    public function test_customers_can_visit_their_customer_portal()
+    {
+        $user = $this->createCustomer('customers_in_stripe_can_be_updated');
+        $user->createAsStripeCustomer();
+
+        $url = $user->customerPortalUrl('https://example.com');
+
+        $this->assertStringStartsWith('https://billing.stripe.com/session/', $url);
+    }
 }

--- a/tests/Feature/CustomerTest.php
+++ b/tests/Feature/CustomerTest.php
@@ -16,22 +16,22 @@ class CustomerTest extends FeatureTestCase
         $this->assertEquals('Mohamed Said', $customer->description);
     }
 
-    public function test_customers_can_generate_a_customer_portal_url()
+    public function test_customers_can_generate_a_billing_portal_url()
     {
         $user = $this->createCustomer('customers_in_stripe_can_be_updated');
         $user->createAsStripeCustomer();
 
-        $url = $user->customerPortalUrl('https://example.com');
+        $url = $user->billingPortalUrl('https://example.com');
 
         $this->assertStringStartsWith('https://billing.stripe.com/session/', $url);
     }
 
-    public function test_customers_can_be_redirected_to_their_customer_portal()
+    public function test_customers_can_be_redirected_to_their_billing_portal()
     {
         $user = $this->createCustomer('customers_in_stripe_can_be_updated');
         $user->createAsStripeCustomer();
 
-        $response = $user->redirectToCustomerPortal('https://example.com');
+        $response = $user->redirectToBillingPortal('https://example.com');
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertStringStartsWith('https://billing.stripe.com/session/', $response->getTargetUrl());


### PR DESCRIPTION
Adds `customerPortalUrl` and `redirectToCustomerPortal` methods.

I was thinking it would be cool if we shipped with a CustomerController and route out of the box so you could just do something like `route('cashier.customer.portal')` but that might be breaking and we'd need to know how to handle multiple guards.